### PR TITLE
Harden PWA caching and clear stale package state

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,24 @@ jobs:
       
       - name: Install dependencies
         run: npm install
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium
+
+      - name: Start dev server
+        run: node server.js &
+
+      - name: Wait for dev server
+        run: sleep 2 && curl -sf http://localhost:8085/ > /dev/null
+
+      - name: Run package catalog tests
+        run: node test_browse_catalog.mjs
+
+      - name: Run TypR workbook tests
+        run: node test_typr_workbooks.mjs
+
+      - name: Run PWA offline catalog tests
+        run: node test_pwa_release.mjs
       
       - name: Add Android platform
         run: npx cap add android || echo "Android platform already exists"
@@ -68,7 +86,7 @@ jobs:
 
             - **Android APK (signed):** Upload pending — download `SciREPL-${{ github.ref_name }}.apk` once available
             - **Android APK (unsigned):** `SciREPL-${{ github.ref_name }}-unsigned.apk` — requires signing before install (see below)
-            - **PWA (zip):** `SciREPL-${{ github.ref_name }}-pwa.zip` — unzip and serve locally, or open `index.html`
+            - **PWA (zip):** `SciREPL-${{ github.ref_name }}-pwa.zip` — unzip and serve over HTTPS or localhost (service workers do not run from `file://`)
             - **PWA (live):** [https://s243a.github.io/SciREPL/](https://s243a.github.io/SciREPL/) — install from browser, no app store needed
 
             ## Updating the PWA

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Run WASM FFI tests
         run: node test_wasm_ffi.mjs
 
+      - name: Run package catalog tests
+        run: node test_browse_catalog.mjs
+
+      - name: Run TypR workbook tests
+        run: node test_typr_workbooks.mjs
+
+      - name: Run PWA offline catalog tests
+        run: node test_pwa_release.mjs
+
   deploy:
     needs: test
     runs-on: ubuntu-latest

--- a/test_browse_catalog.mjs
+++ b/test_browse_catalog.mjs
@@ -25,11 +25,14 @@ const TIMEOUT = 180_000;
 
         const context = browser.contexts()[0];
         await context.addInitScript(() => {
-            localStorage.setItem('scirepl_privacy_accepted', '1');
-            localStorage.setItem('scirepl_installed_packages', JSON.stringify([{
-                name: 'UnifyWeaver SciREPL',
-                pages_url: 'packages/unifyweaver_scirepl.zip'
-            }]));
+            if (!sessionStorage.getItem('catalog_test_seeded')) {
+                sessionStorage.setItem('catalog_test_seeded', '1');
+                localStorage.setItem('scirepl_privacy_accepted', '1');
+                localStorage.setItem('scirepl_installed_packages', JSON.stringify([{
+                    name: 'UnifyWeaver SciREPL',
+                    pages_url: 'packages/unifyweaver_scirepl.zip'
+                }]));
+            }
         });
 
         await page.goto('http://localhost:8085/', { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
@@ -233,6 +236,36 @@ const TIMEOUT = 180_000;
 
         testLog('importIpynb loads workbook content', importResult.hasLifeExp,
             `${importResult.cellsAfter} cells, hasLifeExp=${importResult.hasLifeExp}`);
+
+        // ── Test: Clear History resets catalog installation state ──
+
+        console.log('10. Testing Clear History package-state reset...');
+
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: TIMEOUT }),
+            page.evaluate(() => {
+                const button = document.getElementById('btn-clear-session');
+                button.click();
+                button.click();
+            })
+        ]);
+        await page.waitForSelector('#run-btn:not([disabled])');
+        await page.evaluate(() => document.getElementById('btn-browse-packages').click());
+        const clearedPackageState = await page.evaluate(() => {
+            const cards = [...document.querySelectorAll('#package-catalog-list .pkg-card')];
+            const card = cards.find(item => item.querySelector('strong')?.textContent?.trim() === 'UnifyWeaver SciREPL');
+            const button = card?.querySelector('.pkg-install-btn');
+            return {
+                stored: localStorage.getItem('scirepl_installed_packages'),
+                buttonText: button?.textContent?.trim(),
+                disabled: !!button?.disabled
+            };
+        });
+        testLog('Clear History removes remembered package installations',
+            clearedPackageState.stored === null, clearedPackageState.stored || 'not stored');
+        testLog('Catalog shows Install after Clear History and reload',
+            clearedPackageState.buttonText === 'Install' && !clearedPackageState.disabled,
+            `${clearedPackageState.buttonText}, disabled=${clearedPackageState.disabled}`);
 
         // --- Summary ---
         console.log('\n' + '='.repeat(50));

--- a/test_pwa_release.mjs
+++ b/test_pwa_release.mjs
@@ -1,0 +1,206 @@
+/**
+ * Release PWA regression: serve www/ under a GitHub Pages-style subpath,
+ * activate the real service worker, go offline, and install the UnifyWeaver
+ * bundle (including its package dependency) entirely from the app cache.
+ */
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, resolve, sep } from 'node:path';
+import { chromium } from 'playwright';
+
+const HOST = '127.0.0.1';
+const PORT = 8086;
+const PREFIX = '/SciREPL/';
+const BASE_URL = `http://${HOST}:${PORT}${PREFIX}`;
+const WWW = resolve('www');
+const TIMEOUT = 120_000;
+
+const MIME = {
+    '.css': 'text/css',
+    '.html': 'text/html',
+    '.ipynb': 'application/json',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.mjs': 'text/javascript',
+    '.png': 'image/png',
+    '.srwb': 'application/json',
+    '.wasm': 'application/wasm',
+    '.zip': 'application/zip',
+};
+
+function assert(condition, message, detail = '') {
+    if (!condition) throw new Error(message + (detail ? `: ${detail}` : ''));
+    console.log(`  PASS: ${message}`);
+}
+
+function startStaticServer() {
+    const server = createServer(async (req, res) => {
+        try {
+            const url = new URL(req.url || '/', BASE_URL);
+            if (url.pathname === PREFIX.slice(0, -1)) {
+                res.writeHead(302, { Location: PREFIX });
+                res.end();
+                return;
+            }
+            if (!url.pathname.startsWith(PREFIX)) {
+                res.writeHead(404);
+                res.end('Not found');
+                return;
+            }
+
+            let relative = decodeURIComponent(url.pathname.slice(PREFIX.length));
+            if (!relative || relative.endsWith('/')) relative += 'index.html';
+            let filePath = resolve(WWW, relative);
+            if (filePath !== WWW && !filePath.startsWith(WWW + sep)) {
+                res.writeHead(403);
+                res.end('Forbidden');
+                return;
+            }
+            if ((await stat(filePath)).isDirectory()) filePath = resolve(filePath, 'index.html');
+
+            const body = await readFile(filePath);
+            const headers = {
+                'Content-Type': MIME[extname(filePath)] || 'application/octet-stream',
+                'Cache-Control': filePath.endsWith('sw.js') ? 'no-cache' : 'public, max-age=0',
+            };
+            res.writeHead(200, headers);
+            res.end(body);
+        } catch (_) {
+            res.writeHead(404);
+            res.end('Not found');
+        }
+    });
+    return new Promise((resolveReady, reject) => {
+        server.once('error', reject);
+        server.listen(PORT, HOST, () => resolveReady(server));
+    });
+}
+
+const requiredCatalogPaths = [
+    'packages/unifyweaver_scirepl.zip',
+    'workbooks/01_family_tree_tutorial.ipynb',
+    'workbooks/02_recursion_patterns.ipynb',
+    'workbooks/03_call_graph_analysis.ipynb',
+    'workbooks/prolog-generates-r.srwb',
+    'workbooks/prolog-generates-lua.srwb',
+    'workbooks/life_expectancy_csv_demo.ipynb',
+    'workbooks/r_ggplot2_showcase.ipynb',
+    'workbooks/r_tidyverse_wrangling.ipynb',
+    'workbooks/r_statistics.ipynb',
+    'workbooks/lua-tables-coroutines.srwb',
+    'workbooks/lua-parsing-coroutines.srwb',
+    'workbooks/typr-intro.srwb',
+    'workbooks/prolog-generates-typr.srwb',
+];
+
+const server = await startStaticServer();
+const browser = await chromium.launch({
+    headless: true,
+    args: ['--disable-dev-shm-usage', '--no-sandbox'],
+});
+const context = await browser.newContext();
+const page = await context.newPage();
+page.setDefaultTimeout(TIMEOUT);
+page.on('console', message => console.log(`  BROWSER ${message.type()}: ${message.text()}`));
+page.on('pageerror', error => console.error(`  BROWSER pageerror: ${error.message}`));
+page.on('requestfailed', request => console.error(
+    `  BROWSER requestfailed: ${request.url()} (${request.failure()?.errorText || 'unknown error'})`,
+));
+page.on('dialog', async dialog => {
+    console.log(`  BROWSER dialog: ${dialog.type()}: ${dialog.message()}`);
+    await dialog.dismiss();
+});
+
+try {
+    console.log('1. Installing the service worker from a GitHub Pages-style subpath...');
+    await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+    await page.evaluate(() => {
+        localStorage.clear();
+        localStorage.setItem('scirepl_privacy_accepted', '1');
+        localStorage.setItem('scirepl_auto_switch_workbook', '0');
+        localStorage.setItem('scirepl_auto_download', '1');
+    });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const scope = await page.evaluate(async () => (await navigator.serviceWorker.ready).scope);
+    await page.waitForFunction(() => !!navigator.serviceWorker.controller);
+    assert(scope.endsWith(PREFIX), 'service worker scope preserves the repository subpath', scope);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#run-btn:not([disabled])');
+    assert(await page.evaluate(() => !!navigator.serviceWorker.controller), 'reload is service-worker controlled');
+
+    console.log('2. Verifying every local catalog payload is pre-cached...');
+    const cacheState = await page.evaluate(async () => {
+        const names = await caches.keys();
+        const appCache = names.find(name => name === 'scirepl-app-v122');
+        if (!appCache) return { names, paths: [] };
+        const keys = await (await caches.open(appCache)).keys();
+        return {
+            names,
+            paths: keys.map(request => new URL(request.url).pathname),
+        };
+    });
+    assert(cacheState.names.includes('scirepl-app-v122'), 'release cache v122 is active', cacheState.names.join(', '));
+    for (const relative of requiredCatalogPaths) {
+        assert(cacheState.paths.includes(PREFIX + relative), `pre-cache contains ${relative}`);
+    }
+
+    console.log('3. Warming the CDN-backed Prolog runtime while online...');
+    await page.evaluate(() => window.kernelManager.ensureReady('prolog'));
+    assert(await page.evaluate(() => window.kernelManager.isReady('prolog')), 'Prolog kernel initializes in PWA mode');
+
+    console.log('4. Going offline before installing the dependency-aware bundle...');
+    await context.setOffline(true);
+    const offlineInstall = await page.evaluate(async () => {
+        document.getElementById('btn-browse-packages').click();
+        const catalog = window.packageCatalog;
+        const all = catalog.packages;
+        const bundleIndex = all.findIndex(item => item.id === 'unifyweaver-workbooks');
+        const button = document.querySelector(`.pkg-install-btn[data-idx="${bundleIndex}"]`);
+        await catalog._install(button);
+        return {
+            packageInstalled: catalog._isInstalled(all.find(item => item.id === 'unifyweaver-scirepl')),
+            bundleInstalled: catalog._isInstalled(all[bundleIndex]),
+            notebooks: window.notebookManager.getNotebooks().map(notebook => notebook.name),
+        };
+    });
+    assert(offlineInstall.packageInstalled, 'offline bundle install adds the UnifyWeaver package dependency');
+    assert(offlineInstall.bundleInstalled, 'offline bundle install adds all four workbooks');
+    for (const name of [
+        'Family Tree Tutorial with UnifyWeaver',
+        'Advanced Recursion Patterns in UnifyWeaver',
+        'Call Graph Analysis and SCC Detection',
+        'Prolog Generates R: Compiler Demo',
+    ]) {
+        assert(offlineInstall.notebooks.includes(name), `offline bundle contains ${name}`);
+    }
+
+    // A normal user may decline automatic future downloads. The next offline
+    // launch must still recognize that this CDN runtime is already cached.
+    await page.evaluate(() => localStorage.setItem('scirepl_auto_download', '0'));
+
+    console.log('5. Reloading the complete PWA while still offline...');
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#run-btn:not([disabled])');
+    const offlineReload = await page.evaluate(() => ({
+        controlled: !!navigator.serviceWorker.controller,
+        online: navigator.onLine,
+        title: document.title,
+    }));
+    assert(offlineReload.controlled, 'offline reload remains service-worker controlled');
+    assert(!offlineReload.online, 'browser remained offline during reload');
+    assert(offlineReload.title === 'Sci REPL', 'offline app shell rendered', offlineReload.title);
+
+    console.log('6. Restarting the CDN-backed Prolog kernel while still offline...');
+    await page.evaluate(() => window.kernelManager.ensureReady('prolog'));
+    assert(
+        await page.evaluate(() => window.kernelManager.isReady('prolog')),
+        'cached cross-origin Prolog runtime restarts offline',
+    );
+
+    console.log('\nPWA release regression passed.');
+} finally {
+    await context.setOffline(false).catch(() => {});
+    await browser.close();
+    await new Promise(resolveClose => server.close(resolveClose));
+}

--- a/www/js/file_io.js
+++ b/www/js/file_io.js
@@ -57,6 +57,10 @@ class FileIO {
             window._clearingSession = true; // Prevent beforeunload from re-saving
             localStorage.removeItem('scirepl_session_v2');
             localStorage.removeItem('scirepl_session_v1');
+            // Package installation state belongs to the cleared app history too.
+            // Leaving this behind makes the catalog claim a package is installed
+            // after its session/VFS state has been removed.
+            localStorage.removeItem('scirepl_installed_packages');
             // Also clear IndexedDB (VFS files, search paths, and SharedVFS)
             if (window.vfsStore && window.vfsStore.isReady()) {
                 try {
@@ -1514,7 +1518,7 @@ class FileIO {
                     // Show "Clear Cache" if CDN cache has entries for this runtime
                     if (runtimeInfo && runtimeInfo.cdnHost) {
                         try {
-                            const cdnCache = await caches.open('scirepl-cdn-v1');
+                            const cdnCache = await caches.open(KernelManager.CDN_CACHE);
                             const keys = await cdnCache.keys();
                             const hasCached = keys.some(r => new URL(r.url).hostname === runtimeInfo.cdnHost);
                             if (hasCached) {
@@ -1525,7 +1529,7 @@ class FileIO {
                                     clearBtn.textContent = 'Clearing...';
                                     clearBtn.disabled = true;
                                     try {
-                                        const cache = await caches.open('scirepl-cdn-v1');
+                                        const cache = await caches.open(KernelManager.CDN_CACHE);
                                         const allKeys = await cache.keys();
                                         await Promise.all(
                                             allKeys

--- a/www/js/kernel_manager.js
+++ b/www/js/kernel_manager.js
@@ -175,7 +175,7 @@ class KernelManager {
         let cached = false;
         if (info.cdnHost) {
             try {
-                const cdnCache = await caches.open('scirepl-cdn-v1');
+                const cdnCache = await caches.open(KernelManager.CDN_CACHE);
                 const keys = await cdnCache.keys();
                 cached = keys.some(r => new URL(r.url).hostname === info.cdnHost);
             } catch (_) { }
@@ -407,6 +407,7 @@ class KernelManager {
 
 // Kernels that require CDN downloads
 KernelManager.CDN_KERNELS = new Set(['python', 'prolog', 'r', 'lua']);
+KernelManager.CDN_CACHE = 'scirepl-cdn-v2';
 
 // Runtime display info for download confirmation modal
 KernelManager.RUNTIME_INFO = {

--- a/www/sw.js
+++ b/www/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for SciREPL PWA
 // Caches app shell on install, caches CDN runtimes (Pyodide, swipl-wasm) on first fetch.
 
-const CACHE_VERSION = 'v121';
+const CACHE_VERSION = 'v122';
 const APP_CACHE = 'scirepl-app-' + CACHE_VERSION;
 const CDN_CACHE = 'scirepl-cdn-v2';
 
@@ -58,15 +58,23 @@ const APP_SHELL = [
   './vendor/brush/brush_wasm_bg.wasm',
   './icons/icon-192.png',
   './icons/icon-512.png',
+  // Same-origin catalog payloads. Pre-cache these so an installed PWA can add
+  // packages, bundles, and workbooks without cross-origin or network access.
+  './packages/unifyweaver_scirepl.zip',
+  './workbooks/01_family_tree_tutorial.ipynb',
+  './workbooks/02_recursion_patterns.ipynb',
+  './workbooks/03_call_graph_analysis.ipynb',
+  './workbooks/life_expectancy_csv_demo.ipynb',
+  './workbooks/r_ggplot2_showcase.ipynb',
+  './workbooks/r_tidyverse_wrangling.ipynb',
+  './workbooks/r_statistics.ipynb',
   './workbooks/lua-tables-coroutines.srwb',
   './workbooks/lua-parsing-coroutines.srwb',
   './workbooks/prolog-generates-r.srwb',
   './workbooks/prolog-generates-clojurescript.srwb',
+  './workbooks/prolog-generates-lua.srwb',
   './workbooks/typr-intro.srwb',
   './workbooks/prolog-generates-typr.srwb',
-  './workbooks/01_family_tree_tutorial.ipynb',
-  './workbooks/02_recursion_patterns.ipynb',
-  './workbooks/03_call_graph_analysis.ipynb',
 ];
 
 // CDN domains to cache (Pyodide ~25MB, swipl-wasm ~10MB, webR ~50MB)


### PR DESCRIPTION
## Summary

- pre-cache every same-origin package and workbook catalog payload for offline PWA use
- use the active CDN cache version consistently in runtime detection and cache management
- clear remembered package installations when **Clear History** removes the associated session/VFS state
- add a GitHub Pages-subpath PWA regression covering service-worker scope, online CDN initialization, offline bundle installation, offline reload, and cached runtime restart
- gate both release workflows on the catalog, TypR workbook, and PWA regressions
- clarify that the downloadable PWA must be served over HTTPS or localhost

## Root causes

The service worker did not pre-cache most catalog payloads, and page code inspected `scirepl-cdn-v1` while the service worker populated `scirepl-cdn-v2`. Separately, Clear History removed session and VFS data but retained `scirepl_installed_packages`, producing a stale **Installed** label after Android app reload.

## Validation

- PWA release regression passed under `/SciREPL/`, including offline bundle installation/reload and offline Prolog restart from cached cross-origin assets
- package catalog: 36/36 passed
- both TypR workbook Run All regressions passed
- cell operations: 14/14 passed
- JavaScript kernel: 13/13 passed
- WASM FFI: 18/18 passed
- `git diff --check` passed