### PR TITLE
Allow stale catalog workbooks to be updated

### DIFF
--- a/test_browse_catalog.mjs
+++ b/test_browse_catalog.mjs
@@ -215,9 +215,72 @@ const TIMEOUT = 180_000;
             testLog('Generated TypR queries omit legacy cat(paste(...))', !typrWorkbookResult.hasLegacyCatPaste);
         }
 
+        // ── Test: stale catalog workbook update ──
+
+        console.log('9. Testing stale workbook update...');
+
+        const workbookUpdate = await page.evaluate(async () => {
+            const catalog = window.packageCatalog;
+            const nm = window.notebookManager;
+            const pkg = catalog.packages.find(item => item.id === 'prolog-generates-typr');
+            const pkgIndex = catalog.packages.findIndex(item => item.id === pkg.id);
+
+            // Simulate a workbook restored from before catalog revisions existed.
+            nm.createNotebook({ name: pkg.notebookName });
+            catalog._syncInstallButtons();
+            const button = document.querySelector(`.pkg-install-btn[data-idx="${pkgIndex}"]`);
+            const before = button.textContent.trim();
+
+            const response = await fetch(pkg.pages_url);
+            await catalog._doImport(pkg, await response.blob());
+            catalog._syncInstallButtons();
+
+            const matches = nm.getNotebooks().filter(nb => nb.name === pkg.notebookName);
+            const updated = matches[0];
+            const compileCell = updated?.cells?.find(cell => cell.name === 'compile_to_typr');
+            return {
+                before,
+                after: button.textContent.trim(),
+                disabled: button.disabled,
+                matchCount: matches.length,
+                catalogId: updated?.catalogId,
+                catalogRevision: updated?.catalogRevision,
+                readsNamedCell: compileCell?.code?.includes("nb_read('family_tree', '.code', PrologSrc)") || false
+            };
+        });
+
+        testLog('Stale TypR workbook is labelled Update', workbookUpdate.before === 'Update', workbookUpdate.before);
+        testLog('Update replaces the stale workbook instead of duplicating it',
+            workbookUpdate.matchCount === 1, `${workbookUpdate.matchCount} copies`);
+        testLog('Updated workbook records its catalog revision',
+            workbookUpdate.catalogId === 'prolog-generates-typr' && workbookUpdate.catalogRevision === 2,
+            `${workbookUpdate.catalogId}@${workbookUpdate.catalogRevision}`);
+        testLog('Updated workbook uses the named family_tree cell', workbookUpdate.readsNamedCell);
+        testLog('Updated workbook is labelled Installed',
+            workbookUpdate.after === 'Installed' && workbookUpdate.disabled,
+            `${workbookUpdate.after}, disabled=${workbookUpdate.disabled}`);
+
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        await page.waitForSelector('#run-btn:not([disabled])');
+        await page.evaluate(() => document.getElementById('btn-browse-packages').click());
+        const persistedUpdateState = await page.evaluate(() => {
+            const catalog = window.packageCatalog;
+            const pkg = catalog.packages.find(item => item.id === 'prolog-generates-typr');
+            const notebook = window.notebookManager.getNotebooks().find(nb => nb.name === pkg.notebookName);
+            return {
+                installed: catalog._isInstalled(pkg),
+                catalogId: notebook?.catalogId,
+                catalogRevision: notebook?.catalogRevision
+            };
+        });
+        testLog('Workbook revision survives app reload',
+            persistedUpdateState.installed &&
+            persistedUpdateState.catalogId === 'prolog-generates-typr' &&
+            persistedUpdateState.catalogRevision === 2);
+
         // ── Test: importIpynb integration ──
 
-        console.log('9. Testing importIpynb integration...');
+        console.log('10. Testing importIpynb integration...');
 
         const importResult = await page.evaluate(async () => {
             const resp = await fetch('workbooks/life_expectancy_csv_demo.ipynb');
@@ -239,7 +302,7 @@ const TIMEOUT = 180_000;
 
         // ── Test: Clear History resets catalog installation state ──
 
-        console.log('10. Testing Clear History package-state reset...');
+        console.log('11. Testing Clear History package-state reset...');
 
         await Promise.all([
             page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: TIMEOUT }),

--- a/test_pwa_release.mjs
+++ b/test_pwa_release.mjs
@@ -132,7 +132,7 @@ try {
     console.log('2. Verifying every local catalog payload is pre-cached...');
     const cacheState = await page.evaluate(async () => {
         const names = await caches.keys();
-        const appCache = names.find(name => name === 'scirepl-app-v122');
+        const appCache = names.find(name => name === 'scirepl-app-v123');
         if (!appCache) return { names, paths: [] };
         const keys = await (await caches.open(appCache)).keys();
         return {
@@ -140,7 +140,7 @@ try {
             paths: keys.map(request => new URL(request.url).pathname),
         };
     });
-    assert(cacheState.names.includes('scirepl-app-v122'), 'release cache v122 is active', cacheState.names.join(', '));
+    assert(cacheState.names.includes('scirepl-app-v123'), 'release cache v123 is active', cacheState.names.join(', '));
     for (const relative of requiredCatalogPaths) {
         assert(cacheState.paths.includes(PREFIX + relative), `pre-cache contains ${relative}`);
     }

--- a/www/js/notebook_manager.js
+++ b/www/js/notebook_manager.js
@@ -12,6 +12,8 @@ class Notebook {
         this.name = opts.name || 'Notebook 1';
         this.description = opts.description || '';
         this.kernelLanguage = opts.kernelLanguage || null; // null = infer from cells
+        this.catalogId = opts.catalogId || null;
+        this.catalogRevision = opts.catalogRevision ?? null;
         this.cells = opts.cells || [];
         this.cellCounter = opts.cellCounter || 0;
         this.replContainer = null; // DOM element
@@ -38,6 +40,8 @@ class Notebook {
             name: this.name,
             description: this.description,
             kernelLanguage: this.kernelLanguage,
+            catalogId: this.catalogId,
+            catalogRevision: this.catalogRevision,
             cellCounter: this.cellCounter,
             cells: this.cells.map(c => ({
                 code: c.code,
@@ -56,6 +60,8 @@ class Notebook {
             name: data.name,
             description: data.description,
             kernelLanguage: data.kernelLanguage,
+            catalogId: data.catalogId,
+            catalogRevision: data.catalogRevision,
             cellCounter: data.cellCounter,
             cells: data.cells || []
         });

--- a/www/js/package_catalog.js
+++ b/www/js/package_catalog.js
@@ -183,6 +183,7 @@ class PackageCatalog {
                 description: 'Compile a Prolog transitive-closure predicate to typed TypR, then execute the generated code with native variadic output calls.',
                 type: 'workbook',
                 format: 'srwb',
+                revision: 2,
                 pages_url: 'workbooks/prolog-generates-typr.srwb',
                 size: '~5 KB',
                 kernels: ['prolog', 'typr', 'r'],
@@ -282,28 +283,41 @@ class PackageCatalog {
     }
 
     _isInstalled(pkg) {
-        if (!pkg) return false;
+        return this._installState(pkg) === 'current';
+    }
+
+    _installState(pkg) {
+        if (!pkg) return 'missing';
 
         if ((pkg.type || 'package') === 'package') {
             return this._installedPackages().some(saved =>
-                saved && (saved.id === pkg.id || saved.name === pkg.name));
+                saved && (saved.id === pkg.id || saved.name === pkg.name)) ? 'current' : 'missing';
         }
 
         if (pkg.type === 'workbook') {
             const notebooks = window.notebookManager?.getNotebooks?.() || [];
             const expectedName = pkg.notebookName || pkg.name;
-            return notebooks.some(nb => nb && nb.name === expectedName);
+            const matches = notebooks.filter(nb => nb && nb.name === expectedName);
+            if (matches.length === 0) return 'missing';
+            if (pkg.revision == null) return 'current';
+            return matches.some(nb =>
+                nb.catalogId === pkg.id &&
+                String(nb.catalogRevision) === String(pkg.revision)
+            ) ? 'current' : 'outdated';
         }
 
         if (pkg.type === 'bundle') {
             const dependenciesInstalled = (pkg.requires || []).every(ref =>
                 this._isInstalled(this._findEntry(ref)));
-            const itemsInstalled = (pkg.items || []).every(ref =>
-                this._isInstalled(this._findEntry(ref)));
-            return dependenciesInstalled && itemsInstalled;
+            const itemStates = (pkg.items || []).map(ref =>
+                this._installState(this._findEntry(ref)));
+            if (dependenciesInstalled && itemStates.every(state => state === 'current')) {
+                return 'current';
+            }
+            return itemStates.some(state => state === 'outdated') ? 'outdated' : 'missing';
         }
 
-        return false;
+        return 'missing';
     }
 
     _syncInstallButtons() {
@@ -311,10 +325,10 @@ class PackageCatalog {
         const all = this.packages;
         this.listEl.querySelectorAll('.pkg-install-btn').forEach(btn => {
             const pkg = all[parseInt(btn.dataset.idx, 10)];
-            const installed = this._isInstalled(pkg);
-            btn.textContent = installed ? 'Installed' : 'Install';
-            btn.disabled = installed;
-            btn.classList.toggle('pkg-installed', installed);
+            const state = this._installState(pkg);
+            btn.textContent = state === 'current' ? 'Installed' : (state === 'outdated' ? 'Update' : 'Install');
+            btn.disabled = state === 'current';
+            btn.classList.toggle('pkg-installed', state === 'current');
         });
     }
 
@@ -519,12 +533,12 @@ class PackageCatalog {
         } else if (pkg.type === 'workbook' && pkg.format === 'srwb') {
             const text = await blob.text();
             if (!window.fileIO) throw new Error('File IO not available');
-            window.fileIO.importSrwb(text);
+            await this._importWorkbook(pkg, () => window.fileIO.importSrwb(text));
         } else if (pkg.type === 'workbook') {
             const text = await blob.text();
             if (!window.fileIO) throw new Error('File IO not available');
             // importIpynb now returns a promise (resolves when importCells finishes)
-            await window.fileIO.importIpynb(text);
+            await this._importWorkbook(pkg, () => window.fileIO.importIpynb(text));
         } else {
             const sourceUrl = pkg.url || pkg.pages_url || 'package.zip';
             const urlParts = sourceUrl.split('/');
@@ -533,6 +547,35 @@ class PackageCatalog {
             if (!window.packageLoader) throw new Error('Package loader not available');
             await window.packageLoader.loadFromFile(file);
         }
+    }
+
+    /**
+     * Import a catalog workbook and replace older catalog revisions with the
+     * newly-created notebook. User-created notebooks with other names remain
+     * untouched, and replacement only happens after a successful import.
+     */
+    async _importWorkbook(pkg, importer) {
+        const nm = window.notebookManager;
+        if (!nm) throw new Error('NotebookManager not available');
+
+        const expectedName = pkg.notebookName || pkg.name;
+        const previous = nm.getNotebooks().filter(nb => nb && nb.name === expectedName);
+        await Promise.resolve(importer());
+
+        const matches = nm.getNotebooks().filter(nb => nb && nb.name === expectedName);
+        const imported = [...matches].reverse().find(nb => !previous.includes(nb));
+        if (!imported) throw new Error('Imported workbook was not created: ' + expectedName);
+
+        imported.catalogId = pkg.id;
+        imported.catalogRevision = pkg.revision ?? null;
+
+        // Import first, then remove stale copies, so a parse/import failure can
+        // never destroy the user's existing workbook.
+        for (const oldNotebook of previous) {
+            if (oldNotebook !== imported) nm.removeNotebook(oldNotebook.id);
+        }
+        nm.saveState();
+        return imported;
     }
 
     /**

--- a/www/sw.js
+++ b/www/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for SciREPL PWA
 // Caches app shell on install, caches CDN runtimes (Pyodide, swipl-wasm) on first fetch.
 
-const CACHE_VERSION = 'v122';
+const CACHE_VERSION = 'v123';
 const APP_CACHE = 'scirepl-app-' + CACHE_VERSION;
 const CDN_CACHE = 'scirepl-cdn-v2';
 


### PR DESCRIPTION
## Summary

- persist catalog workbook IDs and revisions with notebook state
- show **Update** when a restored catalog workbook predates its current revision
- import the new workbook successfully before replacing stale same-name copies
- mark the current Prolog Generates TypR workbook revision, whose compiler cells read the named `family_tree` cell through `nb_read/3`
- bump the PWA app cache so existing installations receive the catalog logic

## Root cause

The current bundled TypR workbook already uses the named `family_tree` cell, but SciREPL determined workbook installation solely by notebook name. An older workbook restored from local storage therefore remained labelled **Installed** and could not be refreshed after an APK/PWA upgrade.

## Validation

- package catalog: 42/42, including stale → Update → Installed and persistence across reload
- both TypR workbooks pass Run All with no error cards
- generated TypR compiler reads `family_tree` through `nb_read/3`
- GitHub Pages-style PWA/offline regression passes with app cache v123
- JavaScript syntax checks and `git diff --check` pass