### PR TITLE
Prepare SciREPL v1.0.0 release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,8 +54,8 @@ android {
         applicationId "com.unifyweaver.scirepl"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 8
-        versionName "0.11.0"
+        versionCode 9
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sci-repl",
-    "version": "0.11.0",
+    "version": "1.0.0",
     "description": "Mobile Scientific REPL — Python + Pyodide + Plotly.js",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary

Prepare SciREPL 1.0.0 after the substantial TypR, workbook-bundle, package-catalog, and PWA improvements merged since v0.11.0.

## Changes

- set the npm package version to `1.0.0`
- set Android `versionName` to `1.0.0`
- increment Android `versionCode` from 8 to 9

## Validation

- release metadata parses and reports `1.0.0`
- the catalog regression passes 42/42
- both TypR workbooks pass Run All
- the GitHub Pages/offline PWA lifecycle passes
- `v1.0.0` is not already present

After merge, the `v1.0.0` tag will trigger the existing APK and PWA release workflows.