### PR TITLE
Fix PWA release test hang

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Fetch bundled runtimes
+        run: npm run fetch:bundles
+
       - name: Install Playwright browser
         run: npx playwright install chromium
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Fetch bundled runtimes
+        run: npm run fetch:bundles
+
       - name: Install Playwright browsers
         run: npx playwright install chromium
 

--- a/test_pwa_release.mjs
+++ b/test_pwa_release.mjs
@@ -121,7 +121,16 @@ try {
         localStorage.setItem('scirepl_auto_download', '1');
     });
     await page.reload({ waitUntil: 'domcontentloaded' });
-    const scope = await page.evaluate(async () => (await navigator.serviceWorker.ready).scope);
+    const scope = await page.evaluate(async () => {
+        const registration = await Promise.race([
+            navigator.serviceWorker.ready,
+            new Promise((_, reject) => setTimeout(
+                () => reject(new Error('service worker did not become ready within 30 seconds')),
+                30_000,
+            )),
+        ]);
+        return registration.scope;
+    });
     await page.waitForFunction(() => !!navigator.serviceWorker.controller);
     assert(scope.endsWith(PREFIX), 'service worker scope preserves the repository subpath', scope);
 


### PR DESCRIPTION
## Summary

Fix the v1.0.0 release and Pages workflows hanging indefinitely in the PWA offline catalog regression.

## Root cause

`www/vendor/scittle/scittle.js` is intentionally gitignored and generated by `npm run fetch:bundles`, but the service worker pre-caches that file. Clean GitHub runners did not fetch bundled runtimes before running `test_pwa_release.mjs`, so service-worker installation failed. The test then awaited `navigator.serviceWorker.ready` without a bound and never exited.

## Fix

- fetch bundled runtimes before browser tests in both tag-triggered workflows
- fail service-worker readiness after 30 seconds with an actionable error instead of hanging indefinitely

## Validation

- reproduced the missing-Scittle condition
- confirmed it now fails after 30 seconds rather than hanging
- ran `npm run fetch:bundles` with Node 20 and confirmed it restored Scittle
- reran `node test_pwa_release.mjs`; the complete Pages-subpath and offline lifecycle passed
