### PR TITLE
Use named query cells in Prolog Generates TypR

### DIFF
--- a/test_browse_catalog.mjs
+++ b/test_browse_catalog.mjs
@@ -196,12 +196,19 @@ const TIMEOUT = 180_000;
                 if (!resp.ok) return { fetched: false, error: 'HTTP ' + resp.status };
                 const workbook = await resp.json();
                 const compileCell = workbook.notebook?.cells?.find(cell => cell.name === 'compile_to_typr');
+                const queryCell = workbook.notebook?.cells?.find(cell => cell.name === 'typr_queries');
+                const rCompileCell = workbook.notebook?.cells?.find(cell => cell.name === 'compile_to_r');
+                const rQueryCell = workbook.notebook?.cells?.find(cell => cell.name === 'r_queries');
                 const code = compileCell?.code || '';
                 return {
                     fetched: true,
                     readsNamedPrologCell: code.includes("nb_read('family_tree', '.code', PrologSrc)"),
-                    usesDirectVariadicCat: code.includes('cat("Descendants of alice:", paste(results'),
-                    hasLegacyCatPaste: code.includes('cat(paste(')
+                    readsNamedQueryCell: code.includes("nb_read('typr_queries', '.code', QuerySource)"),
+                    hasInlineQueryProgram: code.includes('format(string(Queries)'),
+                    queryIsSourceCell: queryCell?.language === 'typr' && queryCell?.code?.startsWith('#!source\n'),
+                    usesDirectVariadicCat: queryCell?.code?.includes('cat("Descendants of alice:", paste(results'),
+                    rQueriesAreSeparate: !rCompileCell?.code?.includes('format(string(Queries)') &&
+                        rQueryCell?.language === 'r' && rQueryCell?.code?.includes('ancestor_all("alice")')
                 };
             } catch (e) {
                 return { fetched: false, error: e.message };
@@ -211,8 +218,11 @@ const TIMEOUT = 180_000;
         testLog('Generated TypR workbook fetches from pages_url', typrWorkbookResult.fetched, typrWorkbookResult.error || '');
         if (typrWorkbookResult.fetched) {
             testLog('Generated TypR compiler reads the named Prolog source cell', typrWorkbookResult.readsNamedPrologCell);
+            testLog('Generated TypR compiler reads the named query source cell', typrWorkbookResult.readsNamedQueryCell);
+            testLog('Generated TypR compiler omits inline query programs', !typrWorkbookResult.hasInlineQueryProgram);
+            testLog('Generated TypR queries use a non-executing source cell', typrWorkbookResult.queryIsSourceCell);
             testLog('Generated TypR queries use direct variadic cat', typrWorkbookResult.usesDirectVariadicCat);
-            testLog('Generated TypR queries omit legacy cat(paste(...))', !typrWorkbookResult.hasLegacyCatPaste);
+            testLog('Plain R queries live in their own highlighted cell', typrWorkbookResult.rQueriesAreSeparate);
         }
 
         // ── Test: stale catalog workbook update ──
@@ -245,7 +255,8 @@ const TIMEOUT = 180_000;
                 matchCount: matches.length,
                 catalogId: updated?.catalogId,
                 catalogRevision: updated?.catalogRevision,
-                readsNamedCell: compileCell?.code?.includes("nb_read('family_tree', '.code', PrologSrc)") || false
+                readsNamedCell: compileCell?.code?.includes("nb_read('family_tree', '.code', PrologSrc)") || false,
+                readsNamedQueries: compileCell?.code?.includes("nb_read('typr_queries', '.code', QuerySource)") || false
             };
         });
 
@@ -253,9 +264,10 @@ const TIMEOUT = 180_000;
         testLog('Update replaces the stale workbook instead of duplicating it',
             workbookUpdate.matchCount === 1, `${workbookUpdate.matchCount} copies`);
         testLog('Updated workbook records its catalog revision',
-            workbookUpdate.catalogId === 'prolog-generates-typr' && workbookUpdate.catalogRevision === 2,
+            workbookUpdate.catalogId === 'prolog-generates-typr' && workbookUpdate.catalogRevision === 3,
             `${workbookUpdate.catalogId}@${workbookUpdate.catalogRevision}`);
         testLog('Updated workbook uses the named family_tree cell', workbookUpdate.readsNamedCell);
+        testLog('Updated workbook uses the named typr_queries cell', workbookUpdate.readsNamedQueries);
         testLog('Updated workbook is labelled Installed',
             workbookUpdate.after === 'Installed' && workbookUpdate.disabled,
             `${workbookUpdate.after}, disabled=${workbookUpdate.disabled}`);
@@ -276,7 +288,7 @@ const TIMEOUT = 180_000;
         testLog('Workbook revision survives app reload',
             persistedUpdateState.installed &&
             persistedUpdateState.catalogId === 'prolog-generates-typr' &&
-            persistedUpdateState.catalogRevision === 2);
+            persistedUpdateState.catalogRevision === 3);
 
         // ── Test: importIpynb integration ──
 

--- a/test_pwa_release.mjs
+++ b/test_pwa_release.mjs
@@ -141,7 +141,7 @@ try {
     console.log('2. Verifying every local catalog payload is pre-cached...');
     const cacheState = await page.evaluate(async () => {
         const names = await caches.keys();
-        const appCache = names.find(name => name === 'scirepl-app-v123');
+        const appCache = names.find(name => name === 'scirepl-app-v124');
         if (!appCache) return { names, paths: [] };
         const keys = await (await caches.open(appCache)).keys();
         return {
@@ -149,7 +149,7 @@ try {
             paths: keys.map(request => new URL(request.url).pathname),
         };
     });
-    assert(cacheState.names.includes('scirepl-app-v123'), 'release cache v123 is active', cacheState.names.join(', '));
+    assert(cacheState.names.includes('scirepl-app-v124'), 'release cache v124 is active', cacheState.names.join(', '));
     for (const relative of requiredCatalogPaths) {
         assert(cacheState.paths.includes(PREFIX + relative), `pre-cache contains ${relative}`);
     }

--- a/test_typr_workbooks.mjs
+++ b/test_typr_workbooks.mjs
@@ -99,14 +99,33 @@ async function runAllAndCollect(page) {
             generatedErrors.map(c => `${c.name || '(unnamed)'}: ${c.output}`).join(' | '));
 
         const compileCell = generated.find(c => c.name === 'compile_to_typr');
+        const querySourceCell = generated.find(c => c.name === 'typr_queries');
         const typrCell = generated.find(c => c.name === 'typr_output');
         const rCell = generated.find(c => c.name === 'r_output');
+        const rQueries = generated.find(c => c.name === 'r_queries');
+        const querySourceHighlight = await page.evaluate(() => {
+            const cell = (window._cells || []).find(c => c.name === 'typr_queries');
+            const code = cell?.inputCard?.querySelector('pre code');
+            return { hasCode: !!code, stringTokens: code?.querySelectorAll('.hljs-string').length || 0 };
+        });
         const generatedR = await page.evaluate(source => {
             const kernel = window.kernelManager.getKernel('typr');
             return kernel._typrModule.compile(source).r_code;
         }, typrCell?.code || '');
         assert(compileCell?.code.includes("nb_read('family_tree', '.code', PrologSrc)"),
             'compiler reads Prolog source from the named family_tree cell');
+        assert(querySourceCell?.code.startsWith('#!source\n') &&
+            querySourceCell.code.includes('ancestor_all("alice")'),
+            'TypR queries live in a named source cell');
+        assert(compileCell?.code.includes("nb_read('typr_queries', '.code', QuerySource)"),
+            'compiler reads queries from the named typr_queries cell');
+        assert(!compileCell?.code.includes('format(string(Queries)'),
+            'compiler cell contains no inline TypR query program');
+        assert(querySourceHighlight.hasCode && querySourceHighlight.stringTokens > 0,
+            'TypR query source receives syntax highlighting',
+            JSON.stringify(querySourceHighlight));
+        assert(!querySourceCell?.error && querySourceCell?.output === '',
+            '#!source keeps the named query fragment non-executing during Run All');
         assert(compileCell?.output.includes('TypR code written to cell'), 'Prolog populates the TypR cell');
         assert(typrCell?.code.includes('fn(start: char)') && !typrCell.code.includes('@{'),
             'UnifyWeaver emits native typed TypR without raw-R traversal blocks');
@@ -116,8 +135,12 @@ async function runAllAndCollect(page) {
             `${typrCell?.output}\nGenerated casts:\n${generatedR.split('\n').filter(line => line.includes('as.Array')).join('\n')}`);
         assert(typrCell?.output.includes('alice is ancestor of eve: TRUE'),
             'generated TypR check query succeeds', typrCell?.output);
-        assert(rCell?.output.includes('Descendants of alice:') && !rCell.error,
-            'plain R comparison still executes after TypR', rCell?.output);
+        assert(!rCell?.error && !rCell?.code.includes('Descendants of alice:'),
+            'R compiler output contains definitions rather than appended queries', rCell?.code);
+        assert(rQueries?.output.includes('Descendants of alice:') &&
+            rQueries.output.includes('alice is ancestor of eve: TRUE') && !rQueries.error,
+            'separate highlighted R query cell executes after generated definitions',
+            rQueries?.output);
 
         console.log('\nAll TypR workbook regressions passed.');
     } finally {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -339,7 +339,7 @@
     /** Syntax-highlight code using highlight.js if available. Falls back to escapeHtml. */
     function highlightCode(code, language) {
         if (typeof window.hljs !== 'undefined') {
-            const langMap = { python: 'python', javascript: 'javascript', r: 'r', bash: 'bash', prolog: 'prolog', lua: 'lua' };
+            const langMap = { python: 'python', javascript: 'javascript', r: 'r', typr: 'r', bash: 'bash', prolog: 'prolog', lua: 'lua' };
             const hljsLang = langMap[language];
             if (hljsLang && window.hljs.getLanguage(hljsLang)) {
                 try { return window.hljs.highlight(code, { language: hljsLang }).value; } catch (e) { /* fall through */ }

--- a/www/js/export.js
+++ b/www/js/export.js
@@ -15,7 +15,7 @@ class ExportManager {
     _highlightCode(code, language) {
         if (typeof window.hljs !== 'undefined') {
             // Map SciREPL language names to hljs names
-            const langMap = { python: 'python', javascript: 'javascript', r: 'r', bash: 'bash', prolog: 'prolog' };
+            const langMap = { python: 'python', javascript: 'javascript', r: 'r', typr: 'r', bash: 'bash', prolog: 'prolog' };
             const hljsLang = langMap[language];
             if (hljsLang && window.hljs.getLanguage(hljsLang)) {
                 try {

--- a/www/js/kernels/typr.js
+++ b/www/js/kernels/typr.js
@@ -147,6 +147,7 @@ class TypRKernel {
 
     /**
      * Handle #! directives:
+     *   #!source        — keep a highlighted source fragment without executing it
      *   #!show-r        — toggle showing generated R code
      *   #!typecheck      — type check only, don't execute
      *   #!transpile      — show transpiled R without type checking
@@ -157,6 +158,9 @@ class TypRKernel {
         const rest = lines.slice(1).join('\n').trim();
 
         switch (directive) {
+            case 'source':
+                return { stdout: '', error: null };
+
             case 'show-r':
                 this._showGenerated = !this._showGenerated;
                 return {

--- a/www/js/package_catalog.js
+++ b/www/js/package_catalog.js
@@ -183,7 +183,7 @@ class PackageCatalog {
                 description: 'Compile a Prolog transitive-closure predicate to typed TypR, then execute the generated code with native variadic output calls.',
                 type: 'workbook',
                 format: 'srwb',
-                revision: 2,
+                revision: 3,
                 pages_url: 'workbooks/prolog-generates-typr.srwb',
                 size: '~5 KB',
                 kernels: ['prolog', 'typr', 'r'],

--- a/www/sw.js
+++ b/www/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for SciREPL PWA
 // Caches app shell on install, caches CDN runtimes (Pyodide, swipl-wasm) on first fetch.
 
-const CACHE_VERSION = 'v123';
+const CACHE_VERSION = 'v124';
 const APP_CACHE = 'scirepl-app-' + CACHE_VERSION;
 const CDN_CACHE = 'scirepl-cdn-v2';
 

--- a/www/workbooks/prolog-generates-typr.srwb
+++ b/www/workbooks/prolog-generates-typr.srwb
@@ -6,7 +6,7 @@
     "cells": [
       {
         "type": "markdown",
-        "code": "# Prolog Generates TypR\n\nThis workbook demonstrates UnifyWeaver compiling Prolog predicates into **TypR** — a typed superset of R.\n\nThe workflow:\n1. Define Prolog predicates (facts + rules) in the named `family_tree` cell\n2. Read that cell through the notebook VFS and consult it as Prolog source\n3. UnifyWeaver detects the recursion pattern (transitive closure)\n4. The compiler generates typed TypR code with `let`, `fn`, and type annotations\n5. Execute the generated TypR code in the TypR kernel\n\nKeeping the source in a real Prolog cell preserves syntax highlighting and avoids embedding the program in a string.\n\nThe catalog installs the required **UnifyWeaver SciREPL** package automatically with this workbook.\n\n**Limitation:** TypR variables don't persist across cells — each cell runs independently. All generated code and queries must be in a single cell. Cross-cell persistence is planned for a future release.",
+        "code": "# Prolog Generates TypR\n\nThis workbook demonstrates UnifyWeaver compiling Prolog predicates into **TypR** — a typed superset of R.\n\nThe workflow:\n1. Define Prolog predicates (facts + rules) in the named `family_tree` cell\n2. Define the query program in the named, highlighted `typr_queries` source cell\n3. Read both cells through the notebook VFS\n4. UnifyWeaver detects the recursion pattern (transitive closure)\n5. The compiler generates typed TypR code with `let`, `fn`, and type annotations\n6. Append the named queries and execute the complete program in the TypR kernel\n\nKeeping source programs in named cells preserves syntax highlighting and avoids embedding them in Prolog strings.\n\nThe catalog installs the required **UnifyWeaver SciREPL** package automatically with this workbook.\n\n**Limitation:** TypR cells are isolated. The `#!source` directive keeps `typr_queries` as a non-executing source fragment during **Run All**; `compile_to_typr` appends it to the generated definitions before writing `typr_output`.",
         "language": "markdown"
       },
       {
@@ -23,7 +23,13 @@
       },
       {
         "type": "code",
-        "code": "% Read the highlighted Prolog source from its named cell\nuser:nb_read('family_tree', '.code', PrologSrc),\nsetup_call_cleanup(\n    open('/tmp/_nb_typr_family.pl', write, Out),\n    write(Out, PrologSrc),\n    close(Out)),\ncatch(abolish(parent/2), _, true),\ncatch(abolish(ancestor/2), _, true),\nconsult('/tmp/_nb_typr_family.pl'),\n\n% Compile ancestor/2 to explicitly typed TypR and append queries\nrecursive_compiler:compile_recursive(ancestor/2, [target(typr), typed_mode(explicit)], Code),\nformat('--- Generated TypR code ---~n~w~n', [Code]),\nformat(string(Queries), '~n~n# --- Queries ---~nlet results <- ancestor_all(\"alice\");~ncat(\"Descendants of alice:\", paste(results, collapse=\", \"), \"\\n\");~nlet is_anc <- ancestor_check(\"alice\", \"eve\");~ncat(\"alice is ancestor of eve:\", is_anc, \"\\n\");~nlet is_anc2 <- ancestor_check(\"alice\", \"frank\");~ncat(\"alice is ancestor of frank:\", is_anc2, \"\\n\");~n', []),\nformat(string(FullCode), '~w~w', [Code, Queries]),\nuser:nb_write('typr_output', '.code', FullCode),\nwriteln('TypR code written to cell: typr_output').",
+        "code": "#!source\n# This named TypR source cell is read by compile_to_typr.\n# It is appended to the generated code because TypR cells are isolated.\n\n# --- Queries ---\nlet results <- ancestor_all(\"alice\");\ncat(\"Descendants of alice:\", paste(results, collapse=\", \"), fill = TRUE);\nlet is_anc <- ancestor_check(\"alice\", \"eve\");\ncat(\"alice is ancestor of eve:\", is_anc, fill = TRUE);\nlet is_anc2 <- ancestor_check(\"alice\", \"frank\");\ncat(\"alice is ancestor of frank:\", is_anc2, fill = TRUE);",
+        "language": "typr",
+        "name": "typr_queries"
+      },
+      {
+        "type": "code",
+        "code": "% Read the highlighted Prolog source from its named cell\nuser:nb_read('family_tree', '.code', PrologSrc),\nsetup_call_cleanup(\n    open('/tmp/_nb_typr_family.pl', write, Out),\n    write(Out, PrologSrc),\n    close(Out)),\ncatch(abolish(parent/2), _, true),\ncatch(abolish(ancestor/2), _, true),\nconsult('/tmp/_nb_typr_family.pl'),\n\n% Read the highlighted TypR query program from its named source cell\nuser:nb_read('typr_queries', '.code', QuerySource),\nsplit_string(QuerySource, \"\\n\", \"\\r\", [\"#!source\"|QueryLines]),\natomics_to_string(QueryLines, \"\\n\", Queries),\n\n% Compile ancestor/2 to explicitly typed TypR and append the named queries\nrecursive_compiler:compile_recursive(ancestor/2, [target(typr), typed_mode(explicit)], Code),\nformat('--- Generated TypR code ---~n~w~n', [Code]),\nformat(string(FullCode), '~w~n~n~w~n', [Code, Queries]),\nuser:nb_write('typr_output', '.code', FullCode),\nwriteln('TypR code written to cell: typr_output').",
         "language": "prolog",
         "name": "compile_to_typr"
       },
@@ -45,7 +51,7 @@
       },
       {
         "type": "code",
-        "code": "% Reload the same named Prolog source so this cell runs independently\nuser:nb_read('family_tree', '.code', PrologSrc),\nsetup_call_cleanup(\n    open('/tmp/_nb_r_family.pl', write, Out),\n    write(Out, PrologSrc),\n    close(Out)),\ncatch(abolish(parent/2), _, true),\ncatch(abolish(ancestor/2), _, true),\nconsult('/tmp/_nb_r_family.pl'),\n\n% Compile to R with embedded facts + queries\nrecursive_compiler:compile_recursive(ancestor/2, [target(r), input(embedded)], RCode),\nformat('--- Generated R code ---~n', []),\nformat(string(Queries), '~n~n# --- Queries ---~nresults <- ancestor_all(\"alice\")~ncat(paste(\"Descendants of alice:\", paste(results, collapse=\", \")), \"\\n\")~ncat(paste(\"alice is ancestor of eve:\", ancestor_check(\"alice\", \"eve\")), \"\\n\")~ncat(paste(\"alice is ancestor of frank:\", ancestor_check(\"alice\", \"frank\")), \"\\n\")~n', []),\nformat(string(FullRCode), '~w~w', [RCode, Queries]),\nuser:nb_write('r_output', '.code', FullRCode),\nwriteln('R code written to cell: r_output').",
+        "code": "% Reload the same named Prolog source so this cell runs independently\nuser:nb_read('family_tree', '.code', PrologSrc),\nsetup_call_cleanup(\n    open('/tmp/_nb_r_family.pl', write, Out),\n    write(Out, PrologSrc),\n    close(Out)),\ncatch(abolish(parent/2), _, true),\ncatch(abolish(ancestor/2), _, true),\nconsult('/tmp/_nb_r_family.pl'),\n\n% Compile to R with embedded facts; the highlighted r_queries cell runs next\nrecursive_compiler:compile_recursive(ancestor/2, [target(r), input(embedded)], RCode),\nformat('--- Generated R code ---~n~w~n', [RCode]),\nuser:nb_write('r_output', '.code', RCode),\nwriteln('R code written to cell: r_output').",
         "language": "prolog",
         "name": "compile_to_r"
       },
@@ -54,6 +60,12 @@
         "code": "# This cell will be populated with plain R code.\n# Run the 'compile_to_r' cell above first.",
         "language": "r",
         "name": "r_output"
+      },
+      {
+        "type": "code",
+        "code": "# Query the generated R functions in a separate, highlighted cell.\nresults <- ancestor_all(\"alice\")\ncat(\"Descendants of alice:\", paste(results, collapse=\", \"), \"\\n\")\ncat(\"alice is ancestor of eve:\", ancestor_check(\"alice\", \"eve\"), \"\\n\")\ncat(\"alice is ancestor of frank:\", ancestor_check(\"alice\", \"frank\"), \"\\n\")",
+        "language": "r",
+        "name": "r_queries"
       }
     ]
   }


### PR DESCRIPTION
## What changed

- moves the TypR query program into a named, syntax-highlighted `typr_queries` cell
- adds `#!source` for non-executing TypR source fragments used by Run All workflows
- reads both `family_tree` and `typr_queries` through NotebookVFS
- moves the plain-R comparison queries into a separate `r_queries` cell
- maps TypR cells to the R highlight.js grammar
- bumps the workbook catalog revision to 3 and the PWA cache to v124
- updates catalog, workbook, and offline-PWA regressions

## Why

The compiler input already came from the named Prolog cell, but the TypR query harness was still embedded as a long Prolog string. That obscured syntax highlighting and made the workbook look stale. TypR cells execute in isolated environments, so the named query fragment must still be appended to the generated definitions before execution.

While validating the refactor, the browser test exposed that TypR silently truncates an escaped `\n` string. The query cell now uses the supported named variadic form `cat(..., fill = TRUE)`.

## Validation

- `test_browse_catalog.mjs` — 46/46 passed
- `test_typr_workbooks.mjs` — catalog install and Run All passed
- `test_pwa_release.mjs` — GitHub Pages subpath and offline reload/install passed
- JSON, JavaScript syntax, and `git diff --check` passed