### PR TITLE
Add Android tester onboarding page

### DIFF
--- a/www/pro/index.html
+++ b/www/pro/index.html
@@ -45,7 +45,7 @@
                 <h1 id="hero-title">Turn an idea into an <span>inspectable analysis.</span></h1>
                 <p class="lede">SciREPL Pro combines a multi-language notebook with an AI assistant that can build, run, and refine workbooks directly on your Android device.</p>
                 <div class="hero-actions">
-                    <a class="button button-primary" href="https://github.com/s243a/SciREPL/issues/new?title=SciREPL%20Pro%20tester%20request" target="_blank" rel="noopener noreferrer">Join Android testing</a>
+                    <a class="button button-primary" href="testing.html">Join Android testing</a>
                     <a class="button button-secondary" href="../">Open the free version</a>
                 </div>
                 <p class="availability">Google Play release in preparation · Tester access available</p>
@@ -149,7 +149,7 @@
                         <li>Remote Codex and Claude Code workflows</li>
                         <li>More packages available without an initial download</li>
                     </ul>
-                    <a class="text-link" href="https://github.com/s243a/SciREPL/issues/new?title=SciREPL%20Pro%20tester%20request" target="_blank" rel="noopener noreferrer">Request tester access <span aria-hidden="true">→</span></a>
+                    <a class="text-link" href="testing.html">Join Android testing <span aria-hidden="true">→</span></a>
                 </article>
             </div>
         </section>
@@ -171,7 +171,7 @@
             <h2 id="cta-title">Test SciREPL Pro on Android.</h2>
             <p>Early testers can try the free and Pro editions while the Google Play release is being prepared.</p>
             <div class="hero-actions">
-                <a class="button button-primary" href="https://github.com/s243a/SciREPL/issues/new?title=SciREPL%20Pro%20tester%20request" target="_blank" rel="noopener noreferrer">Become a tester</a>
+                <a class="button button-primary" href="testing.html">Become a tester</a>
                 <a class="button button-secondary" href="https://github.com/s243a/SciREPL" target="_blank" rel="noopener noreferrer">View public source</a>
             </div>
         </section>

--- a/www/pro/styles.css
+++ b/www/pro/styles.css
@@ -607,6 +607,216 @@ footer p {
     font-size: 0.92rem;
 }
 
+.testing-hero {
+    max-width: 900px;
+    padding: 96px 0 72px;
+}
+
+.testing-hero h1 {
+    font-size: clamp(3.2rem, 7vw, 6.3rem);
+}
+
+.account-note {
+    display: inline-flex;
+    gap: 8px;
+    margin-top: 28px;
+    padding: 10px 14px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: rgba(85, 169, 255, 0.07);
+    color: var(--muted);
+    font-size: 0.88rem;
+}
+
+.account-note strong {
+    color: var(--ink);
+}
+
+.testing-steps {
+    margin: 0;
+    padding: 0;
+    border-top: 1px solid var(--line);
+    list-style: none;
+}
+
+.testing-step {
+    display: grid;
+    grid-template-columns: 64px minmax(0, 1fr);
+    gap: 34px;
+    padding: 72px 0;
+    border-bottom: 1px solid var(--line);
+}
+
+.step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border: 1px solid rgba(0, 226, 210, 0.3);
+    border-radius: 18px;
+    background: rgba(0, 226, 210, 0.09);
+    color: var(--cyan);
+    font-size: 1.25rem;
+    font-weight: 800;
+}
+
+.step-content {
+    max-width: 940px;
+}
+
+.step-content h2,
+.testing-help h2 {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 3.45rem);
+    letter-spacing: -0.045em;
+    line-height: 1.05;
+}
+
+.step-content > p:not(.eyebrow) {
+    max-width: 750px;
+    margin: 18px 0 0;
+    color: var(--muted);
+    font-size: 1.03rem;
+}
+
+.step-actions,
+.store-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 28px;
+}
+
+.test-options {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+    margin-top: 31px;
+}
+
+.test-option {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 29px;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: linear-gradient(150deg, rgba(14, 49, 80, 0.72), rgba(6, 25, 44, 0.76));
+}
+
+.test-option-pro {
+    border-color: rgba(255, 200, 87, 0.31);
+    background:
+        linear-gradient(145deg, rgba(255, 200, 87, 0.08), transparent 42%),
+        linear-gradient(150deg, rgba(14, 49, 80, 0.82), rgba(6, 25, 44, 0.82));
+}
+
+.test-label {
+    margin: 0;
+    color: var(--cyan);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.test-option-pro .test-label {
+    color: var(--gold);
+}
+
+.test-option h3 {
+    margin: 11px 0 10px;
+    font-size: 1.65rem;
+    letter-spacing: -0.03em;
+}
+
+.test-option > p:not(.test-label) {
+    flex: 1;
+    margin: 0 0 24px;
+    color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.tester-code-note,
+.membership-note {
+    display: grid;
+    gap: 4px;
+    margin-top: 20px;
+    padding: 17px 19px;
+    border: 1px solid rgba(255, 200, 87, 0.28);
+    border-radius: 13px;
+    background: rgba(255, 200, 87, 0.07);
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.tester-code-note strong {
+    color: var(--gold);
+}
+
+.membership-note {
+    max-width: 780px;
+    border-color: rgba(85, 169, 255, 0.25);
+    background: rgba(85, 169, 255, 0.07);
+}
+
+.membership-note strong {
+    color: var(--blue);
+}
+
+.tester-checklist {
+    display: grid;
+    gap: 10px;
+    max-width: 720px;
+    margin: 30px 0 0;
+    padding: 0;
+    color: #c5d4e2;
+    list-style: none;
+}
+
+.tester-checklist li {
+    position: relative;
+    padding-left: 26px;
+}
+
+.tester-checklist li::before {
+    position: absolute;
+    left: 0;
+    color: var(--cyan);
+    content: "✓";
+}
+
+.feedback-actions {
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    margin-top: 29px;
+}
+
+.feedback-actions p {
+    max-width: 550px;
+    margin: 0;
+    color: var(--quiet);
+    font-size: 0.82rem;
+}
+
+.testing-help {
+    display: grid;
+    grid-template-columns: minmax(0, 0.85fr) minmax(360px, 1.15fr);
+    gap: 76px;
+    margin: 80px 0 100px;
+    padding: clamp(29px, 5vw, 52px);
+    border: 1px solid var(--line);
+    border-radius: 24px;
+    background: rgba(10, 35, 61, 0.58);
+}
+
+.testing-help p:not(.eyebrow) {
+    margin: 5px 0 20px;
+    color: var(--muted);
+}
+
 @media (max-width: 900px) {
     nav a:not(.nav-cta) {
         display: none;
@@ -632,7 +842,8 @@ footer p {
 
     .section-heading,
     .workflow-section,
-    .privacy-section {
+    .privacy-section,
+    .testing-help {
         grid-template-columns: 1fr;
         gap: 38px;
     }
@@ -737,6 +948,10 @@ footer p {
         grid-template-columns: 1fr;
     }
 
+    .test-options {
+        grid-template-columns: 1fr;
+    }
+
     .edition-card {
         padding: 27px;
     }
@@ -758,6 +973,36 @@ footer p {
 
     .cta {
         margin-bottom: 70px;
+    }
+
+    .testing-hero {
+        padding: 66px 0 54px;
+    }
+
+    .testing-step {
+        grid-template-columns: 46px minmax(0, 1fr);
+        gap: 16px;
+        padding: 54px 0;
+    }
+
+    .step-number {
+        width: 42px;
+        height: 42px;
+        border-radius: 12px;
+        font-size: 1rem;
+    }
+
+    .account-note {
+        display: grid;
+        gap: 1px;
+    }
+
+    .feedback-actions {
+        display: grid;
+    }
+
+    .testing-help {
+        margin: 62px 0 74px;
     }
 
     footer {

--- a/www/pro/testing.html
+++ b/www/pro/testing.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Join the SciREPL Android closed tests for the Free and Pro editions through Google Play.">
+    <meta name="theme-color" content="#071c36">
+    <link rel="canonical" href="https://s243a.github.io/SciREPL/pro/testing.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Become a SciREPL Android tester">
+    <meta property="og:description" content="Join the tester group, opt into the Free and Pro tests, and help prepare SciREPL for Google Play.">
+    <meta property="og:url" content="https://s243a.github.io/SciREPL/pro/testing.html">
+    <meta property="og:image" content="https://s243a.github.io/SciREPL/pro/assets/SciREPL-Pro-feature-graphic-1024x500.png">
+    <meta property="og:image:width" content="1024">
+    <meta property="og:image:height" content="500">
+    <meta property="og:image:alt" content="SciREPL Pro scientific notebook interface">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="icon" type="image/png" href="assets/SciREPL-Pro-app-icon-512.png">
+    <link rel="stylesheet" href="styles.css">
+    <title>Become a SciREPL Android tester</title>
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+        <a class="brand" href="./" aria-label="SciREPL Pro home">
+            <img src="assets/SciREPL-Pro-app-icon-512.png" alt="" width="44" height="44">
+            <span>sci<span>REPL</span> <b>PRO</b></span>
+        </a>
+        <nav aria-label="Primary navigation">
+            <a href="./">Pro overview</a>
+            <a href="privacy.html">Privacy</a>
+            <a class="nav-cta" href="../">Try free PWA</a>
+        </nav>
+    </header>
+
+    <main id="main" class="testing-main">
+        <section class="testing-hero" aria-labelledby="testing-title">
+            <p class="eyebrow">Android closed testing</p>
+            <h1 id="testing-title">Help test <span>SciREPL.</span></h1>
+            <p class="lede">Google Play only shows the test releases to members of the SciREPL tester group. Complete these steps using the same Google account you use in the Play Store.</p>
+            <div class="account-note" role="note">
+                <strong>Already in the group?</strong>
+                <span>Start at step 2.</span>
+            </div>
+        </section>
+
+        <ol class="testing-steps">
+            <li class="testing-step">
+                <span class="step-number" aria-hidden="true">1</span>
+                <div class="step-content">
+                    <p class="eyebrow">Step 1 · Get access</p>
+                    <h2>Join the Google Group</h2>
+                    <p>The group is the tester access list for both editions. Join it with the Google account connected to your Android device.</p>
+                    <div class="step-actions">
+                        <a class="button button-primary" href="https://groups.google.com/g/scirepl-android-testers" target="_blank" rel="noopener noreferrer">Join the tester group</a>
+                    </div>
+                    <div class="membership-note" role="note">
+                        <strong>About your membership information</strong>
+                        <span>Group owners and managers can see the email address and Google profile you use to join. This information is used to manage tester access and deliver Pro testing codes. Conversations are visible to group members, and you can set your group email subscription to <em>No email</em>.</span>
+                    </div>
+                </div>
+            </li>
+
+            <li class="testing-step">
+                <span class="step-number" aria-hidden="true">2</span>
+                <div class="step-content">
+                    <p class="eyebrow">Step 2 · Opt in</p>
+                    <h2>Join both Google Play tests</h2>
+                    <p>Open each page and select <strong>Become a tester</strong>. Google may take a few minutes to recognize new group membership.</p>
+                    <div class="test-options">
+                        <article class="test-option">
+                            <p class="test-label">Free &amp; open source</p>
+                            <h3>SciREPL</h3>
+                            <p>The multi-language notebook without the AI assistant panel.</p>
+                            <a class="button button-secondary" href="https://play.google.com/apps/testing/com.unifyweaver.scirepl" target="_blank" rel="noopener noreferrer">Opt into Free</a>
+                        </article>
+                        <article class="test-option test-option-pro">
+                            <p class="test-label">Android Pro edition</p>
+                            <h3>SciREPL Pro</h3>
+                            <p>The notebook with the integrated AI assistant and additional bundled packages.</p>
+                            <a class="button button-secondary" href="https://play.google.com/apps/testing/com.unifyweaver.scirepl.pro" target="_blank" rel="noopener noreferrer">Opt into Pro</a>
+                        </article>
+                    </div>
+                    <div class="tester-code-note" role="note">
+                        <strong>Wait for your Pro tester code before purchasing.</strong>
+                        <span>After you join the group, the developer will send a one-time 100%-off Google Play code privately to the email address on your group membership. Redeem it in Google Play before completing the purchase so you are not charged. If it does not arrive, request a code in the tester group.</span>
+                    </div>
+                </div>
+            </li>
+
+            <li class="testing-step">
+                <span class="step-number" aria-hidden="true">3</span>
+                <div class="step-content">
+                    <p class="eyebrow">Step 3 · Install &amp; test</p>
+                    <h2>Open the Play Store listings</h2>
+                    <p>Once you have opted in, install the apps from Google Play. Please remain opted in for at least 14 consecutive days and try the apps during that period.</p>
+                    <div class="store-links">
+                        <a class="button button-primary" href="https://play.google.com/store/apps/details?id=com.unifyweaver.scirepl" target="_blank" rel="noopener noreferrer">Install SciREPL Free</a>
+                        <a class="button button-secondary" href="https://play.google.com/store/apps/details?id=com.unifyweaver.scirepl.pro" target="_blank" rel="noopener noreferrer">Open SciREPL Pro</a>
+                    </div>
+                    <ul class="tester-checklist">
+                        <li>Run several included workbooks and check their output.</li>
+                        <li>Try creating, editing, saving, and reopening a workbook.</li>
+                        <li>Report crashes, confusing behaviour, or device-specific problems.</li>
+                    </ul>
+                    <div class="feedback-actions">
+                        <a class="button button-secondary" href="https://groups.google.com/g/scirepl-android-testers" target="_blank" rel="noopener noreferrer">Share feedback in the tester group</a>
+                        <p>Group conversations can be seen by other members. Never post API keys, pairing tokens, private workbook contents, or personal information.</p>
+                    </div>
+                </div>
+            </li>
+        </ol>
+
+        <section class="testing-help" aria-labelledby="testing-help-title">
+            <div>
+                <p class="eyebrow">Having trouble?</p>
+                <h2 id="testing-help-title">If Google Play says you are not eligible</h2>
+            </div>
+            <div>
+                <p>Confirm that the Google Group, testing pages, and Play Store all use the same Google account. Then wait a few minutes and open the opt-in page again.</p>
+                <a class="text-link" href="https://groups.google.com/g/scirepl-android-testers" target="_blank" rel="noopener noreferrer">Open the tester group <span aria-hidden="true">→</span></a>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <a class="brand footer-brand" href="./" aria-label="SciREPL Pro home">
+            <img src="assets/SciREPL-Pro-app-icon-512.png" alt="" width="36" height="36">
+            <span>sci<span>REPL</span> <b>PRO</b></span>
+        </a>
+        <div>
+            <a href="./">Pro overview</a>
+            <a href="privacy.html">Privacy</a>
+            <a href="../">Free PWA</a>
+        </div>
+        <p>© 2026 SciREPL</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add a dedicated SciREPL Android tester onboarding page
- guide testers through joining the Google Group, opting into both Play tracks, and installing the apps
- explain Pro promo-code delivery, tester feedback, membership privacy, and common eligibility problems
- route all Pro landing-page testing buttons to the new instructions instead of opening a GitHub issue

## Why

The closed tracks now use a Google Group as their tester list. The previous landing-page buttons skipped that eligibility step, so prospective testers could reach Google Play before they were authorized and receive a confusing access error.

## Impact

This changes only the public GitHub Pages content under `www/pro/`; application code and packaged builds are unaffected.

## Validation

- validated the new page with `html-validate`
- served both Pro pages locally and confirmed the new page and stylesheet load
- verified the Google Group, Free/Pro opt-in, and store URLs
- confirmed all three landing-page testing calls to action now use the new page
- ran `git diff --check`