### PR TITLE
Phase 0: Windows Electron feasibility spike (Free only)

### DIFF
--- a/.github/workflows/windows-electron-spike.yml
+++ b/.github/workflows/windows-electron-spike.yml
@@ -106,6 +106,16 @@ jobs:
       - name: Install the Playwright Chromium build
         run: npx playwright install chromium
 
+      # Launch the shell directly, without Playwright, and print the main
+      # process's own stdout/stderr. Playwright reports a failed Electron launch
+      # as a bare timeout with no output, which is nearly undiagnosable on a
+      # machine you cannot log into. This runs first so its output is available
+      # even when the suite below fails, and it retries once with GPU/sandbox
+      # flags so a host-configuration problem is distinguishable from a broken
+      # shell in a single run.
+      - name: Smoke-launch the shell (diagnostic)
+        run: node desktop/electron/test/smoke.mjs
+
       # SCIREPL_COMPARE_BASELINE=1 is what makes the step above load-bearing:
       # without it the suite never calls chromium.launch() and the download would
       # be dead weight. It also buys the thing this job exists for — the

--- a/.github/workflows/windows-electron-spike.yml
+++ b/.github/workflows/windows-electron-spike.yml
@@ -28,6 +28,18 @@ on:
       - '.github/workflows/windows-electron-spike.yml'
   workflow_dispatch:
 
+  # TEMPORARY — remove in the commit that merges this branch.
+  #
+  # GitHub only offers `workflow_dispatch` for workflows that already exist on
+  # the default branch, so a brand-new workflow file cannot be dispatched
+  # against its own PR head. Without this trigger there is no way to get a green
+  # Windows run *before* merging, which is the order review asked for.
+  #
+  # Scoped to this one branch so it is not a gate on anything else.
+  push:
+    branches:
+      - 'feat/electron-windows-spike'
+
 # Never cancel someone else's Android/PWA run; scope concurrency to this file.
 concurrency:
   group: windows-electron-spike-${{ github.ref }}
@@ -62,7 +74,10 @@ jobs:
 
   windows-shell:
     name: Electron shell on Windows (manual)
-    if: github.event_name == 'workflow_dispatch'
+    # Runs on explicit dispatch, and on pushes to the spike branch (see the
+    # temporary `push` trigger above). Never on ordinary pull requests — it is
+    # unproven and downloads ~330 MB, so it must not gate other people's work.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
@@ -84,8 +99,22 @@ jobs:
       - name: Install Electron
         run: npm run windows:install
 
-      - name: Run the Electron shell suite
+      # Playwright is the shared test driver: `_electron.launch()` drives the
+      # shell and `chromium.launch()` drives the browser baseline. `npm install`
+      # brings in the Playwright package but does NOT provision browser binaries,
+      # so the Chromium download must be explicit.
+      - name: Install the Playwright Chromium build
+        run: npx playwright install chromium
+
+      # SCIREPL_COMPARE_BASELINE=1 is what makes the step above load-bearing:
+      # without it the suite never calls chromium.launch() and the download would
+      # be dead weight. It also buys the thing this job exists for — the
+      # kernel-parity claim in docs/WINDOWS_ELECTRON_SPIKE.md was measured on
+      # Linux, and this re-measures Electron-vs-browser parity on real Windows.
+      - name: Run the Electron shell suite (with browser baseline)
         run: npm run test:windows
+        env:
+          SCIREPL_COMPARE_BASELINE: '1'
 
       - name: Upload results
         if: always()

--- a/.github/workflows/windows-electron-spike.yml
+++ b/.github/workflows/windows-electron-spike.yml
@@ -4,20 +4,24 @@
 # depend on. build-release.yml and deploy-pages.yml are unchanged, and neither
 # job here is a required check for them.
 #
-# Two jobs with deliberately different triggers:
+# Two jobs:
 #
 #   shell-policy  — pure Node unit tests (path containment, external-URL policy,
 #                   IPC allowlist, CSP shape). No display, no Electron download,
-#                   a few seconds. Safe to run on every PR that touches the shell.
+#                   a few seconds.
 #
-#   windows-shell — the full Electron suite on a real Windows runner. This is
-#                   `workflow_dispatch` only, on purpose: it downloads ~220 MB of
-#                   Electron plus ~104 MB of kernel runtimes and drives a GUI
-#                   application, and it has NOT yet been observed to pass on a
-#                   Windows runner (the spike was developed on Linux). Making it
-#                   an automatic gate before anyone has seen it go green would
-#                   block PRs on an unproven job. Promote it to `pull_request`
-#                   once it has been run manually and is stable.
+#   windows-shell — the full Electron suite on a real Windows runner, including
+#                   the Playwright Chromium baseline comparison. Verified green
+#                   on windows-latest (199 assertions, 0 failures, all 8 kernels
+#                   at browser parity).
+#
+# Both run only on pull requests that touch the shell, because that is the
+# change that can break them. windows-shell downloads ~220 MB of Electron plus
+# ~104 MB of kernel runtimes and drives a GUI application, so it is bounded by
+# `timeout-minutes` and kept off every other PR by the paths filter. It also
+# reaches CDN hosts for the browser-baseline comparison; if that proves flaky in
+# practice, drop it back to `workflow_dispatch` rather than letting a red job
+# become background noise.
 
 name: Windows Electron spike
 
@@ -27,18 +31,6 @@ on:
       - 'desktop/electron/**'
       - '.github/workflows/windows-electron-spike.yml'
   workflow_dispatch:
-
-  # TEMPORARY — remove in the commit that merges this branch.
-  #
-  # GitHub only offers `workflow_dispatch` for workflows that already exist on
-  # the default branch, so a brand-new workflow file cannot be dispatched
-  # against its own PR head. Without this trigger there is no way to get a green
-  # Windows run *before* merging, which is the order review asked for.
-  #
-  # Scoped to this one branch so it is not a gate on anything else.
-  push:
-    branches:
-      - 'feat/electron-windows-spike'
 
 # Never cancel someone else's Android/PWA run; scope concurrency to this file.
 concurrency:
@@ -73,11 +65,7 @@ jobs:
         run: node desktop/electron/test/run-all.mjs --unit
 
   windows-shell:
-    name: Electron shell on Windows (manual)
-    # Runs on explicit dispatch, and on pushes to the spike branch (see the
-    # temporary `push` trigger above). Never on ordinary pull requests — it is
-    # unproven and downloads ~330 MB, so it must not gate other people's work.
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    name: Electron shell on Windows
     runs-on: windows-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/windows-electron-spike.yml
+++ b/.github/workflows/windows-electron-spike.yml
@@ -1,0 +1,96 @@
+# Phase 0 Windows/Electron feasibility spike.
+#
+# Additive by design: this workflow touches nothing the Android or PWA pipelines
+# depend on. build-release.yml and deploy-pages.yml are unchanged, and neither
+# job here is a required check for them.
+#
+# Two jobs with deliberately different triggers:
+#
+#   shell-policy  — pure Node unit tests (path containment, external-URL policy,
+#                   IPC allowlist, CSP shape). No display, no Electron download,
+#                   a few seconds. Safe to run on every PR that touches the shell.
+#
+#   windows-shell — the full Electron suite on a real Windows runner. This is
+#                   `workflow_dispatch` only, on purpose: it downloads ~220 MB of
+#                   Electron plus ~104 MB of kernel runtimes and drives a GUI
+#                   application, and it has NOT yet been observed to pass on a
+#                   Windows runner (the spike was developed on Linux). Making it
+#                   an automatic gate before anyone has seen it go green would
+#                   block PRs on an unproven job. Promote it to `pull_request`
+#                   once it has been run manually and is stable.
+
+name: Windows Electron spike
+
+on:
+  pull_request:
+    paths:
+      - 'desktop/electron/**'
+      - '.github/workflows/windows-electron-spike.yml'
+  workflow_dispatch:
+
+# Never cancel someone else's Android/PWA run; scope concurrency to this file.
+concurrency:
+  group: windows-electron-spike-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shell-policy:
+    name: Shell policy unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Only the shell's own dependency tree is needed, and the unit tests do
+      # not require the Electron binary itself.
+      - name: Install shell dependencies (no Electron download)
+        run: npm --prefix desktop/electron install --ignore-scripts
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
+      # No build profile, no www/ tree and no display are required: these tests
+      # exercise the shell's pure decision functions only.
+      - name: Run policy unit tests
+        run: node desktop/electron/test/run-all.mjs --unit
+
+  windows-shell:
+    name: Electron shell on Windows (manual)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install root dependencies
+        run: npm install
+
+      - name: Configure Free build profile
+        run: npm run configure
+
+      - name: Fetch bundled runtimes
+        run: npm run fetch:bundles
+
+      - name: Install Electron
+        run: npm run windows:install
+
+      - name: Run the Electron shell suite
+        run: npm run test:windows
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-electron-results
+          path: desktop/electron/test/results/
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ www/vendor/pyodide/
 www/vendor/swipl/
 www/vendor/scittle/
 www/vendor/webr/
+
+# Windows/Electron shell (desktop/electron). The downloaded Electron runtime
+# lives under its own node_modules/ (already ignored above); these are the
+# packaging output and test artifacts, which must never be committed.
+desktop/electron/dist/
+desktop/electron/out/
+desktop/electron/release/
+desktop/electron/test/results/

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -1,0 +1,141 @@
+# SciREPL — Windows/Electron shell (Phase 0 feasibility spike)
+
+A thin Electron shell around the **existing** prepared `www/` application. It is
+the Windows-specific half of the split described in
+[`docs/WINDOWS_STORE_PROPOSAL.md`](../../docs/WINDOWS_STORE_PROPOSAL.md):
+
+```
+www/, kernels, WASM, workbooks, formats, persistence   ← shared, untouched
+android/, capacitor.config.json                        ← Android only
+desktop/electron/                                      ← Windows only  (this directory)
+```
+
+Nothing here is referenced by the Android project, and nothing here imports
+Capacitor. The shared application code imports neither framework — the shell
+loads `www/` exactly as the PWA does, and the app takes its existing browser
+code paths because `window.Capacitor` is absent.
+
+**Status: feasibility spike, Free edition only.** There is no packaging, no
+Microsoft Store integration and no entitlement logic here, deliberately. See
+[`docs/WINDOWS_ELECTRON_SPIKE.md`](../../docs/WINDOWS_ELECTRON_SPIKE.md) for
+measured results and the recommendation.
+
+## Commands
+
+Run from the repository root:
+
+```bash
+npm run windows:install    # install Electron (isolated; see "Dependency isolation")
+npm run dev:windows        # configure + fetch runtimes + launch the shell
+npm run test:windows       # all shell tests (needs Electron + a display)
+npm run test:windows:unit  # policy unit tests only (no display, no Electron binary)
+```
+
+Individual suites:
+
+```bash
+node desktop/electron/test/run-all.mjs security persistence
+SCIREPL_COMPARE_BASELINE=1 node desktop/electron/test/kernels.test.mjs
+```
+
+These are additive. `npm run build`, `build:release:aab`, `build:play` and the
+Android/PWA workflows are untouched.
+
+### Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `SCIREPL_WWW` | serve a different prepared `www/` tree |
+| `SCIREPL_USER_DATA` | use a specific profile directory (the persistence tests rely on this) |
+| `SCIREPL_COMPARE_BASELINE=1` | also run the kernel probes in plain Chromium and compare |
+| `SCIREPL_ELECTRON_NO_SANDBOX=1` | launch with `--no-sandbox` for containers without a usable setuid helper. The security suite records this and refuses to claim the sandbox was verified. |
+
+## Dependency isolation
+
+Electron is declared in `desktop/electron/package.json`, **not** in the root
+`package.json`. That is the point: `npm install` at the repository root — which
+is what the Android build and the existing CI do — must not download a ~220 MB
+Chromium runtime. Only `npm run windows:install` does.
+
+Electron is pinned exactly (`43.3.0`, no range).
+
+## Origin model
+
+The shell serves the application from a custom standard scheme:
+
+```
+app://scirepl/index.html
+```
+
+registered as `standard`, `secure`, `supportFetchAPI`, `corsEnabled`, `stream`
+and `allowServiceWorkers`.
+
+`file://` was rejected, not merely disliked: it gives documents an **opaque**
+origin, which in Chromium means no service worker registration, unreliable
+IndexedDB, blocked `fetch()` of relative URLs, and no `Content-Type`, so
+`WebAssembly.instantiateStreaming` rejects. A stable non-opaque origin is what
+makes notebook and SharedVFS state survive a restart. This is verified by
+`test/persistence.test.mjs`, not assumed.
+
+`protocol.js` is the only place that maps a URL to a file, and it refuses
+anything that escapes `www/` (including percent-encoded traversal).
+
+## Security model
+
+The renderer is treated as **fully untrusted**, because SciREPL's JavaScript
+kernel executes notebook cells with `new AsyncFunction(code)` in the main world
+(`www/js/kernels/javascript.js`). There is no realm boundary between SciREPL's
+own UI code and user-authored notebook code, so anything reachable from `window`
+is reachable by a notebook cell.
+
+The shell therefore **withholds capability rather than filtering it**:
+
+| Setting | Value |
+| --- | --- |
+| `nodeIntegration` | `false` (also in workers and sub-frames) |
+| `contextIsolation` | `true` |
+| `sandbox` | `true` |
+| `webviewTag` | `false` |
+| remote module | not installed, not enabled |
+| exposed API | `getAppInfo()`, `getDistributionInfo()` — read-only, nullary |
+
+There is no `invoke`, `send`, filesystem, or shell escape hatch. Navigation off
+the app origin is blocked; `target="_blank"` links are handed to the system
+browser via `setWindowOpenHandler` and never open a child window. Permission
+requests are denied wholesale. A restrictive CSP is applied to documents and
+scripts by the protocol handler, so `www/index.html` is unchanged and the PWA
+is unaffected.
+
+`'unsafe-eval'` and `'wasm-unsafe-eval'` are permitted and cannot be removed —
+the JavaScript kernel, Scittle and Pyodide all require them. The CSP is
+restrictive about *origins*, which is the part that protects a packaged app.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `main.js` | lifecycle, window creation, single-instance lock, storage flush on quit |
+| `protocol.js` | the `app://` scheme, MIME types, path containment, CSP |
+| `security.js` | navigation / window-open / permission policy |
+| `preload.js` | the entire renderer-visible surface (two read-only calls) |
+| `ipc.js` | the canonical IPC allowlist, owned by the main process |
+| `test/` | see below |
+
+## Tests
+
+| Suite | Needs Electron? | Covers |
+| --- | --- | --- |
+| `policy.unit.test.mjs` | no | path containment, external-URL policy, IPC allowlist, CSP shape |
+| `shell-launch.test.mjs` | yes | origin, secure context, relative assets, WASM MIME + streaming, reload |
+| `security.test.mjs` | yes | Node unreachable from notebook code, preload surface, navigation policy, webPreferences |
+| `artifact-boundary.test.mjs` | yes | Free-only content; no bundled R, no entitlement code |
+| `download.test.mjs` | yes | blob URLs and the `<a download>` path under `app://` |
+| `persistence.test.mjs` | yes | IndexedDB / SharedVFS / localStorage across a real restart |
+| `kernels.test.mjs` | yes | one execution per kernel + SharedVFS; optional browser A/B |
+| `offline.test.mjs` | yes | bundled kernels with the network cut; CDN kernels fail cleanly |
+
+`test/probes/kernels.mjs` holds the kernel assertions and is driven by **both**
+the Electron runner and the Chromium baseline runner, so a difference in results
+is a real platform difference rather than two divergent test suites. Export
+*correctness* is not re-tested here — the existing browser tests in the
+repository root already cover it and that logic is platform-independent.

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -159,6 +159,20 @@ drifting. The proper fix is a shared change — replace the widget with a plain
 | `kernels.test.mjs` | yes | one execution per kernel + SharedVFS; optional browser A/B |
 | `offline.test.mjs` | yes | bundled kernels with the network cut; CDN kernels fail cleanly |
 
+Two tools sit alongside the suites and are run explicitly, not by `run-all`:
+
+```bash
+node desktop/electron/test/smoke.mjs            # launch diagnostic
+node desktop/electron/test/measure.mjs --with-python   # startup/size/memory
+```
+
+`smoke.mjs` launches the shell **directly, without Playwright**, and prints the
+main process's own stdout/stderr — Playwright reports any launch failure as a
+bare timeout with no output, which is close to undiagnosable on a CI machine.
+On failure it retries once with `--disable-gpu --no-sandbox
+--disable-software-rasterizer`, so one run distinguishes a broken shell from a
+host that needs GPU flags. Reach for it first whenever the shell will not start.
+
 `test/probes/kernels.mjs` holds the kernel assertions and is driven by **both**
 the Electron runner and the Chromium baseline runner, so a difference in results
 is a real platform difference rather than two divergent test suites. Export

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -38,6 +38,15 @@ node desktop/electron/test/run-all.mjs security persistence
 SCIREPL_COMPARE_BASELINE=1 node desktop/electron/test/kernels.test.mjs
 ```
 
+Playwright is the shared test driver — `_electron.launch()` drives the shell and
+`chromium.launch()` drives the browser baseline. `npm install` provides the
+Playwright *package* but not its browser binaries, so the baseline comparison
+additionally needs:
+
+```bash
+npx playwright install chromium
+```
+
 These are additive. `npm run build`, `build:release:aab`, `build:play` and the
 Android/PWA workflows are untouched.
 
@@ -109,6 +118,22 @@ is unaffected.
 `'unsafe-eval'` and `'wasm-unsafe-eval'` are permitted and cannot be removed —
 the JavaScript kernel, Scittle and Pyodide all require them. The CSP is
 restrictive about *origins*, which is the part that protects a packaged app.
+
+### Known divergence: the Ko-fi widget
+
+`www/index.html:407` loads the Ko-fi support widget from
+`https://storage.ko-fi.com`. That origin is **deliberately not** on the
+allowlist, so the widget is blocked and the support button does not appear in
+the shell. It degrades silently — the widget is already guarded by
+`if (typeof kofiwidget2 !== 'undefined')` — and the rest of the Help panel is
+unaffected.
+
+Allowing it would grant a third-party host arbitrary script execution in the
+same realm that runs user notebooks, which is not a trade worth making for a
+donate button. See `KOFI_EXCLUSION` in `protocol.js`; the exclusion is pinned by
+`policy.unit.test.mjs` and `security.test.mjs` so it stays a decision rather than
+drifting. The proper fix is a shared change — replace the widget with a plain
+`target="_blank"` link — which is proposed as Phase 1 follow-up work.
 
 ## Files
 

--- a/desktop/electron/ipc.js
+++ b/desktop/electron/ipc.js
@@ -1,0 +1,72 @@
+/**
+ * ipc.js — the canonical IPC allowlist, owned by the main process.
+ *
+ * Every handler here is registered explicitly. There is no dynamic dispatch,
+ * no `invoke(name, ...args)` router, and no channel derived from renderer
+ * input — those patterns collapse the allowlist into a single generic hole.
+ *
+ * Each handler validates that it received no arguments. Both Phase 0
+ * operations are nullary, so any argument at all means the caller is not the
+ * preload API and the call is rejected rather than tolerated.
+ */
+
+const { ipcMain, app } = require('electron');
+
+const CHANNELS = Object.freeze({
+  APP_INFO: 'scirepl:get-app-info',
+  DISTRIBUTION_INFO: 'scirepl:get-distribution-info',
+});
+
+/** Reject any call that carries arguments. */
+function assertNullary(channel, args) {
+  if (args.length > 0) {
+    throw new Error(`${channel}: expected no arguments, received ${args.length}`);
+  }
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.appVersion  version read from the repo package.json
+ * @param {string} options.profile     build profile the www/ tree was configured with
+ */
+function registerIpcHandlers(options = {}) {
+  const appVersion = options.appVersion || '0.0.0';
+  const profile = options.profile || 'unknown';
+
+  ipcMain.handle(CHANNELS.APP_INFO, (_event, ...args) => {
+    assertNullary(CHANNELS.APP_INFO, args);
+    return {
+      appVersion,
+      electronVersion: process.versions.electron,
+      chromeVersion: process.versions.chrome,
+      nodeVersion: process.versions.node,
+      platform: process.platform,
+      arch: process.arch,
+      packaged: app.isPackaged,
+    };
+  });
+
+  ipcMain.handle(CHANNELS.DISTRIBUTION_INFO, (_event, ...args) => {
+    assertNullary(CHANNELS.DISTRIBUTION_INFO, args);
+    return {
+      // Phase 0 is Free-only by construction. This value is a build fact, not
+      // an entitlement: it is not a licence check and must never become one.
+      // The future Microsoft Store seam (StoreContext.GetAppLicenseAsync) would
+      // live in the main process behind its own narrow channel and is
+      // deliberately NOT stubbed here — a placeholder that always returns
+      // "licensed" would be worse than no implementation.
+      edition: 'free',
+      container: 'electron',
+      packaged: app.isPackaged,
+      profile,
+      store: null,
+    };
+  });
+}
+
+/** Used by tests to assert the surface has not silently grown. */
+function listRegisteredChannels() {
+  return Object.values(CHANNELS);
+}
+
+module.exports = { CHANNELS, registerIpcHandlers, listRegisteredChannels, assertNullary };

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -1,0 +1,163 @@
+/**
+ * main.js — SciREPL Windows/Electron shell (Phase 0 feasibility spike, Free only).
+ *
+ * This is intentionally a thin shell. It does not modify, wrap or reimplement
+ * any application behaviour: it establishes a stable secure origin (protocol.js),
+ * locks the renderer down (security.js, preload.js), and loads the same prepared
+ * `www/` tree that the PWA and the Capacitor/Android build already use.
+ *
+ * No Capacitor code is referenced here, and nothing in this directory is
+ * reachable from the Android project.
+ */
+
+const { app, BrowserWindow, session } = require('electron');
+const path = require('path');
+const fs = require('fs');
+
+const {
+  START_URL,
+  ORIGIN,
+  registerScheme,
+  registerProtocolHandler,
+} = require('./protocol');
+const { applyWebContentsPolicy } = require('./security');
+const { registerIpcHandlers } = require('./ipc');
+
+/** Repository root, two levels up from desktop/electron/. */
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WWW_ROOT = process.env.SCIREPL_WWW || path.join(REPO_ROOT, 'www');
+
+/**
+ * A distinct userData directory. The shell must not collide with any other
+ * Electron app's storage, and keeping it explicit makes the "does IndexedDB
+ * survive restart" test meaningful and lets tests point at a scratch profile.
+ */
+if (process.env.SCIREPL_USER_DATA) {
+  app.setPath('userData', process.env.SCIREPL_USER_DATA);
+} else {
+  app.setPath('userData', path.join(app.getPath('appData'), 'SciREPL-Free-Electron'));
+}
+
+function readAppVersion() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function readProfile() {
+  // scripts/configure-build.mjs writes www/js/kernel_config.js from
+  // build-profiles.json. Report which profile the tree was configured with so
+  // the shell never has to guess which kernels should be present.
+  try {
+    const src = fs.readFileSync(path.join(WWW_ROOT, 'js', 'kernel_config.js'), 'utf8');
+    // Generated form is `"profile": "full"` inside window.KERNEL_CONFIG.
+    const m = src.match(/["']?profile["']?\s*:\s*["']([^"']+)["']/);
+    if (m) return m[1];
+  } catch { /* fall through */ }
+  return 'unknown';
+}
+
+/** Scheme registration must happen before the app is ready. */
+registerScheme();
+
+// Single instance: a second launch focuses the existing window rather than
+// opening a second renderer against the same IndexedDB, which would risk
+// concurrent writes to notebooks and SharedVFS.
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+}
+
+let mainWindow = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 860,
+    minWidth: 480,
+    minHeight: 480,
+    show: false,
+    backgroundColor: '#0d1117', // matches the app's theme-color, avoids white flash
+    title: 'SciREPL',
+    webPreferences: {
+      // --- the security boundary ---
+      nodeIntegration: false,
+      nodeIntegrationInWorker: false,
+      nodeIntegrationInSubFrames: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      allowRunningInsecureContent: false,
+      experimentalFeatures: false,
+      webviewTag: false,
+      navigateOnDragDrop: false,
+      spellcheck: false,
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  applyWebContentsPolicy(mainWindow.webContents);
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow.show();
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+
+  mainWindow.loadURL(START_URL);
+  return mainWindow;
+}
+
+app.on('second-instance', () => {
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.focus();
+  }
+});
+
+app.whenReady().then(() => {
+  registerProtocolHandler(WWW_ROOT);
+  registerIpcHandlers({ appVersion: readAppVersion(), profile: readProfile() });
+
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+/**
+ * Shutdown. Ask Chromium to flush the storage partition so notebook and
+ * SharedVFS writes that are still buffered reach disk if the user quits while
+ * a kernel is running.
+ *
+ * This deliberately does NOT preventDefault() and force an exit. An earlier
+ * revision did, and it deadlocked graceful shutdown: the quit was cancelled and
+ * restarted from inside the handler, so callers waiting for a normal exit
+ * (Playwright's electronApp.close(), and by extension a user's window-close)
+ * never observed one. Chromium already tears the session down correctly on a
+ * normal quit; the flush is the only thing worth adding.
+ */
+app.on('before-quit', () => {
+  try {
+    session.defaultSession.flushStorageData();
+  } catch { /* best effort — never block shutdown */ }
+});
+
+app.on('window-all-closed', () => {
+  // Windows/Linux: quitting with the last window is the expected behaviour.
+  if (process.platform !== 'darwin') app.quit();
+});
+
+/**
+ * Refuse to create any additional renderer with unsafe preferences, and apply
+ * the same policy to every WebContents the app ever creates.
+ */
+app.on('web-contents-created', (_event, contents) => {
+  applyWebContentsPolicy(contents);
+});

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -68,7 +68,13 @@ registerScheme();
 // concurrent writes to notebooks and SharedVFS.
 const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
+  // `return` is legal at the top level of a CommonJS module and stops the rest
+  // of this file from running. Without it, a losing instance called quit() and
+  // then went on to register `whenReady` and build a window anyway — a process
+  // that is quitting but still waiting for `ready` never becomes ready and never
+  // exits, which presents as a launch that hangs until it is killed.
   app.quit();
+  return;
 }
 
 let mainWindow = null;
@@ -120,11 +126,54 @@ app.on('second-instance', () => {
   }
 });
 
+/**
+ * Smoke mode (SCIREPL_SMOKE_EXIT=1): load the app once, print a machine-readable
+ * verdict on stdout, and exit.
+ *
+ * This exists because Playwright reports a failed Electron launch as an opaque
+ * timeout with no output from the main process, which makes a CI-only startup
+ * failure very hard to diagnose. Running the shell directly and printing what
+ * happened turns that into a one-line answer. It is inert unless the variable
+ * is set, and it never runs during normal use or the test suite proper.
+ */
+function runSmokeCheck(win) {
+  const done = (line, code) => {
+    console.log(line);
+    setImmediate(() => app.exit(code));
+  };
+
+  const timer = setTimeout(
+    () => done('SCIREPL_SMOKE_FAIL timeout: window never finished loading', 3),
+    60_000
+  );
+
+  win.webContents.once('did-finish-load', () => {
+    clearTimeout(timer);
+    done(`SCIREPL_SMOKE_OK url=${win.webContents.getURL()}`, 0);
+  });
+
+  win.webContents.once('did-fail-load', (_e, code, desc, url) => {
+    clearTimeout(timer);
+    done(`SCIREPL_SMOKE_FAIL did-fail-load code=${code} desc=${desc} url=${url}`, 2);
+  });
+
+  win.webContents.once('render-process-gone', (_e, details) => {
+    clearTimeout(timer);
+    done(`SCIREPL_SMOKE_FAIL render-process-gone reason=${details && details.reason}`, 4);
+  });
+}
+
 app.whenReady().then(() => {
+  if (process.env.SCIREPL_SMOKE_EXIT === '1') {
+    console.log(`SCIREPL_SMOKE_READY electron=${process.versions.electron} chrome=${process.versions.chrome} www=${WWW_ROOT}`);
+  }
+
   registerProtocolHandler(WWW_ROOT);
   registerIpcHandlers({ appVersion: readAppVersion(), profile: readProfile() });
 
   createWindow();
+
+  if (process.env.SCIREPL_SMOKE_EXIT === '1') runSmokeCheck(mainWindow);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -1,0 +1,174 @@
+{
+  "name": "scirepl-desktop-electron",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scirepl-desktop-electron",
+      "version": "0.0.0",
+      "devDependencies": {
+        "electron": "43.3.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron": {
+      "version": "43.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.3.0.tgz",
+      "integrity": "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scirepl-desktop-electron",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Phase 0 Windows feasibility shell for SciREPL Free. Isolated from the root Android/PWA dependency tree on purpose.",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "node test/run-all.mjs"
+  },
+  "devDependencies": {
+    "electron": "43.3.0"
+  }
+}

--- a/desktop/electron/preload.js
+++ b/desktop/electron/preload.js
@@ -1,0 +1,63 @@
+/**
+ * preload.js — the entire renderer-visible native surface.
+ *
+ * Design rule for Phase 0: because notebook code shares the renderer realm with
+ * SciREPL's UI code (see security.js), every operation exposed here must be
+ * safe when invoked by hostile notebook code. Operations that are not safe
+ * under that assumption are simply not exposed.
+ *
+ * That leaves two read-only, side-effect-free operations. They carry no
+ * authority: they return static build/platform facts that the application uses
+ * for display and for adapter selection. Nothing here can read a file, write a
+ * file, spawn a process, or reach an arbitrary IPC channel.
+ *
+ * Deliberately NOT exposed in Phase 0, and why:
+ *   - a generic `invoke`/`send` escape hatch — it would export the whole main
+ *     process to notebook code in one line;
+ *   - `require`, `process`, `Buffer`, `__dirname` — Node is off entirely
+ *     (nodeIntegration: false, sandbox: true);
+ *   - filesystem or shell operations — the browser download/upload paths in
+ *     www/js/file_io.js already work under the app:// origin, so native file
+ *     access buys nothing for the feasibility question while adding a
+ *     capability notebook code could reach;
+ *   - `openExternal` — SciREPL's external links are `target="_blank"` anchors,
+ *     which the main process already handles via setWindowOpenHandler. Routing
+ *     them there keeps the decision in the main process where it belongs.
+ *
+ * When Phase 1 introduces saveFile/openFile, each must be its own narrow,
+ * schema-validated channel that shows a native dialog, so the user — not the
+ * calling code — chooses the path. See docs/WINDOWS_ELECTRON_SPIKE.md.
+ */
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+/**
+ * The complete IPC allowlist. Adding a channel here is the only way to widen
+ * the surface, and each entry is invoked with no renderer-supplied arguments.
+ */
+const CHANNELS = Object.freeze({
+  APP_INFO: 'scirepl:get-app-info',
+  DISTRIBUTION_INFO: 'scirepl:get-distribution-info',
+});
+
+/**
+ * Both operations take zero arguments by design. There is no argument to
+ * validate and therefore no argument-shaped attack surface. If a future
+ * operation needs arguments, validation belongs in the main process
+ * (ipc.js), never here — the preload runs in the renderer process and a
+ * compromised renderer could bypass any check made on this side.
+ */
+const api = {
+  /** Static application/build identity. */
+  getAppInfo: () => ipcRenderer.invoke(CHANNELS.APP_INFO),
+
+  /** Which container/edition this is, for adapter selection. */
+  getDistributionInfo: () => ipcRenderer.invoke(CHANNELS.DISTRIBUTION_INFO),
+};
+
+contextBridge.exposeInMainWorld('sciREPLPlatform', Object.freeze(api));
+
+// Nothing is exported: this file runs as a sandboxed preload, which cannot
+// `require` relative modules. The channel names above are duplicated in
+// ipc.js, which owns the canonical allowlist; test/preload-boundary.test.mjs
+// asserts the two agree by exercising the running application.

--- a/desktop/electron/protocol.js
+++ b/desktop/electron/protocol.js
@@ -1,0 +1,262 @@
+/**
+ * protocol.js — the application origin for the Windows/Electron shell.
+ *
+ * Why not file://
+ * ---------------
+ * SciREPL is an origin-sensitive application: IndexedDB (notebooks + SharedVFS),
+ * a service worker, workers spawned by Pyodide/webR, WebAssembly streaming
+ * instantiation and relative asset resolution all key off the page origin.
+ * `file://` gives each document an *opaque* origin, which in Chromium means:
+ *   - IndexedDB is unavailable or unpartitioned/unstable across loads,
+ *   - service workers are not registrable at all,
+ *   - `fetch()` of relative URLs is blocked,
+ *   - responses carry no Content-Type, so `WebAssembly.instantiateStreaming`
+ *     rejects (`.wasm` must be served as `application/wasm`).
+ *
+ * So the shell registers ONE stable, secure, standard scheme and serves the
+ * prepared `www/` tree from it:
+ *
+ *     app://scirepl/index.html
+ *
+ * `standard` gives it real origin semantics (storage keying, relative URLs).
+ * `secure` makes it a Secure Context, which is what service workers, crypto.subtle
+ * and several kernel runtimes require. The origin is constant across launches and
+ * across packaged/unpackaged builds, so IndexedDB survives restart and upgrade.
+ *
+ * This module is deliberately the only place that maps a URL to a file.
+ */
+
+const { protocol, net } = require('electron');
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const SCHEME = 'app';
+const HOST = 'scirepl';
+const ORIGIN = `${SCHEME}://${HOST}`;
+const START_URL = `${ORIGIN}/index.html`;
+
+/**
+ * Content types. Superset of the dev server's map (server.js) — the shell must
+ * agree with the dev server so behaviour does not silently diverge between
+ * `npm run serve` (browser baseline) and the packaged shell.
+ */
+const MIME = {
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.wasm': 'application/wasm',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+  '.ttf': 'font/ttf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.otf': 'font/otf',
+  '.eot': 'application/vnd.ms-fontobject',
+  '.py': 'text/x-python',
+  '.pl': 'text/plain',
+  '.R': 'text/plain',
+  '.r': 'text/plain',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.csv': 'text/csv',
+  '.zip': 'application/zip',
+  '.gz': 'application/gzip',
+  '.tar': 'application/x-tar',
+  '.data': 'application/octet-stream',
+  '.srwb': 'application/json',
+  '.ipynb': 'application/json',
+  '.webmanifest': 'application/manifest+json',
+};
+
+/**
+ * Remote origins the application legitimately contacts. Derived from
+ * build-profiles.json, www/js/package_catalog.js and www/index.html rather than
+ * guessed, so the CSP does not have to be loosened later by trial and error.
+ */
+const REMOTE_ORIGINS = [
+  'https://cdn.jsdelivr.net',      // Pyodide, Scittle, swipl-wasm
+  'https://data.jsdelivr.com',     // jsDelivr version metadata
+  'https://unpkg.com',             // Pyodide/Fengari mirror
+  'https://github.com',            // package + workbook releases
+  'https://objects.githubusercontent.com', // GitHub release asset redirect target
+  'https://api.github.com',        // release metadata
+  'https://raw.githubusercontent.com',
+  'https://repo.r-wasm.org',       // R/WebAssembly package repository
+  'https://webr.r-wasm.org',       // webR runtime
+  'https://pypi.org',              // micropip
+  'https://files.pythonhosted.org',// micropip wheels
+];
+
+/**
+ * Content-Security-Policy for the application origin.
+ *
+ * `'unsafe-eval'` is present deliberately and cannot be removed: SciREPL's
+ * JavaScript kernel compiles cells with `new AsyncFunction(...)`, Scittle
+ * compiles ClojureScript at runtime, and Pyodide/webR rely on eval-family
+ * constructs. WebAssembly compilation also requires `'wasm-unsafe-eval'`.
+ * The CSP is therefore restrictive about *where code and data may come from*,
+ * which is the property that actually protects the packaged app, and permissive
+ * about eval, which the product fundamentally requires.
+ *
+ * Note this is defence in depth, not the security boundary. The boundary is
+ * contextIsolation + sandbox + the absence of an exposed privileged API
+ * (see preload.js and security.js).
+ */
+function buildCsp() {
+  const remote = REMOTE_ORIGINS.join(' ');
+  return [
+    `default-src 'self' ${ORIGIN}`,
+    `script-src 'self' ${ORIGIN} 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline' blob: ${remote}`,
+    `style-src 'self' ${ORIGIN} 'unsafe-inline' ${remote}`,
+    `img-src 'self' ${ORIGIN} data: blob: ${remote}`,
+    `font-src 'self' ${ORIGIN} data: ${remote}`,
+    `connect-src 'self' ${ORIGIN} data: blob: ${remote}`,
+    `worker-src 'self' ${ORIGIN} blob:`,
+    `child-src 'self' ${ORIGIN} blob:`,
+    // No plugins, and the page may never be framed.
+    `object-src 'none'`,
+    `frame-ancestors 'none'`,
+    // Keep form posts and <base> hijacking off the table.
+    `base-uri 'self'`,
+    `form-action 'none'`,
+  ].join('; ');
+}
+
+/**
+ * Must be called before `app.whenReady()`. Chromium needs privileged scheme
+ * registration during startup, before the network stack is created.
+ */
+function registerScheme() {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: SCHEME,
+      privileges: {
+        standard: true,        // real origin => stable storage key, relative URLs
+        secure: true,          // Secure Context => service worker, crypto.subtle
+        supportFetchAPI: true, // fetch() of app:// URLs (kernels load assets this way)
+        corsEnabled: true,
+        stream: true,          // range/streaming responses for large WASM payloads
+        allowServiceWorkers: true,
+        codeCache: true,
+      },
+    },
+  ]);
+}
+
+/**
+ * Resolve an app:// pathname to a real file inside `root`, refusing anything
+ * that escapes the root. Returns null when the request is not serviceable.
+ */
+function resolveRequestPath(root, pathname) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return null; // malformed percent-encoding
+  }
+
+  // Reject NUL and any traversal before touching the filesystem.
+  if (decoded.includes('\0')) return null;
+
+  const relative = decoded.replace(/^\/+/, '');
+  const candidate = path.resolve(root, relative === '' ? 'index.html' : relative);
+
+  // Containment check. path.relative is the reliable form: it must not start
+  // with '..' and must not be absolute.
+  const rel = path.relative(root, candidate);
+  if (rel === '' ) return null;
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+
+  return candidate;
+}
+
+/**
+ * Install the app:// handler. `root` is the prepared www/ directory.
+ * Called after `app.whenReady()`.
+ */
+function registerProtocolHandler(root) {
+  const csp = buildCsp();
+
+  protocol.handle(SCHEME, async (request) => {
+    const url = new URL(request.url);
+
+    if (url.hostname !== HOST) {
+      return new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } });
+    }
+
+    // Only GET/HEAD are meaningful for a static application bundle.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', { status: 405, headers: { 'content-type': 'text/plain' } });
+    }
+
+    let filePath = resolveRequestPath(root, url.pathname);
+    if (!filePath) {
+      return new Response('Forbidden', { status: 403, headers: { 'content-type': 'text/plain' } });
+    }
+
+    let stat;
+    try {
+      stat = await fsp.stat(filePath);
+    } catch {
+      return new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } });
+    }
+
+    if (stat.isDirectory()) {
+      const indexPath = path.join(filePath, 'index.html');
+      try {
+        const indexStat = await fsp.stat(indexPath);
+        if (!indexStat.isFile()) throw new Error('not a file');
+        filePath = indexPath;
+      } catch {
+        return new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } });
+      }
+    }
+
+    const ext = path.extname(filePath);
+    const type = MIME[ext] || MIME[ext.toLowerCase()] || 'application/octet-stream';
+
+    const headers = {
+      'content-type': type,
+      // The bundle is local and immutable for the life of a build; the service
+      // worker still manages its own cache identity on top of this.
+      'cache-control': 'no-cache',
+      'x-content-type-options': 'nosniff',
+    };
+
+    // Apply the CSP to documents and workers only. Attaching it to every asset
+    // is redundant and, for worker scripts, is what actually governs them.
+    if (type === 'text/html' || type === 'text/javascript') {
+      headers['content-security-policy'] = csp;
+    }
+
+    // Delegate the actual byte delivery to Electron's net stack so we get
+    // streaming and range support for the large runtime payloads (Pyodide,
+    // webR) without buffering them in the main process.
+    const response = await net.fetch(pathToFileURL(filePath).toString());
+    return new Response(response.body, { status: 200, headers });
+  });
+}
+
+module.exports = {
+  SCHEME,
+  HOST,
+  ORIGIN,
+  START_URL,
+  MIME,
+  REMOTE_ORIGINS,
+  buildCsp,
+  registerScheme,
+  registerProtocolHandler,
+  resolveRequestPath,
+};

--- a/desktop/electron/protocol.js
+++ b/desktop/electron/protocol.js
@@ -80,9 +80,18 @@ const MIME = {
 };
 
 /**
- * Remote origins the application legitimately contacts. Derived from
- * build-profiles.json, www/js/package_catalog.js and www/index.html rather than
- * guessed, so the CSP does not have to be loosened later by trial and error.
+ * Remote origins the application is allowed to contact from the packaged shell.
+ *
+ * These cover the runtime/package supply chain — the kernel CDNs in
+ * build-profiles.json and the release/package hosts in www/js/package_catalog.js.
+ *
+ * This is an ALLOWLIST, not an inventory of everything www/index.html happens to
+ * reference. One origin present in the PWA is deliberately absent:
+ *
+ *   https://storage.ko-fi.com  — the Ko-fi support widget (www/index.html:407)
+ *
+ * See KOFI_EXCLUSION below for why, and desktop/electron/test/security.test.mjs
+ * for the test that keeps the omission deliberate rather than accidental.
  */
 const REMOTE_ORIGINS = [
   'https://cdn.jsdelivr.net',      // Pyodide, Scittle, swipl-wasm
@@ -97,6 +106,40 @@ const REMOTE_ORIGINS = [
   'https://pypi.org',              // micropip
   'https://files.pythonhosted.org',// micropip wheels
 ];
+
+/**
+ * A known, deliberate divergence from the PWA.
+ *
+ * `www/index.html:407` loads the Ko-fi support widget as a third-party script
+ * from `https://storage.ko-fi.com`. It is NOT in REMOTE_ORIGINS, so the CSP
+ * blocks it and the support button does not appear in the shell. The widget is
+ * already guarded by `if (typeof kofiwidget2 !== 'undefined')`, so blocking it
+ * degrades silently: nothing throws and no other Help content is affected.
+ *
+ * Why it is excluded rather than allowed:
+ *
+ *   - It is a third-party script with no role in running notebooks. Adding it to
+ *     `script-src` grants an external host arbitrary script execution inside the
+ *     same realm that runs user notebooks and holds all IndexedDB state. The
+ *     supply-chain cost is out of proportion to a donate button.
+ *   - The CSP's whole value here is being restrictive about origins; widening it
+ *     for a non-functional widget spends exactly the property worth keeping.
+ *
+ * This is a divergence, not a fix. The right resolution is a shared change —
+ * replace the widget with a plain `target="_blank"` link to the Ko-fi page,
+ * which works identically in the PWA, on Android and here, and needs no CSP
+ * exception at all. That belongs in a follow-up because it touches `www/`,
+ * which this Phase 0 spike deliberately does not modify.
+ *
+ * Exported so the test suite can assert the exclusion stays intentional.
+ */
+const KOFI_EXCLUSION = Object.freeze({
+  origin: 'https://storage.ko-fi.com',
+  site: 'www/index.html:407',
+  effect: 'the Ko-fi support button does not render in the Electron shell',
+  degradesSilently: true,
+  resolution: 'replace the widget with a plain external link in a shared follow-up change',
+});
 
 /**
  * Content-Security-Policy for the application origin.
@@ -255,6 +298,7 @@ module.exports = {
   START_URL,
   MIME,
   REMOTE_ORIGINS,
+  KOFI_EXCLUSION,
   buildCsp,
   registerScheme,
   registerProtocolHandler,

--- a/desktop/electron/security.js
+++ b/desktop/electron/security.js
@@ -1,0 +1,160 @@
+/**
+ * security.js — navigation, window and permission policy for the shell.
+ *
+ * Threat model
+ * ------------
+ * There are two kinds of code inside the renderer and they are NOT separated
+ * by a realm boundary:
+ *
+ *   1. SciREPL's own UI code (www/js/**).
+ *   2. User-authored notebook code and downloaded packages.
+ *
+ * The JavaScript kernel executes cells with `new AsyncFunction(code)` in the
+ * main world (www/js/kernels/javascript.js). Scittle, Lua/Fengari and Pyodide's
+ * JS bridge likewise reach the same `window`. Therefore **anything reachable
+ * from `window` is reachable by notebook code**, and the shell must assume a
+ * notebook cell is hostile.
+ *
+ * The consequence, which drives every decision in this file and preload.js:
+ * the renderer is treated as fully untrusted. It gets no Node, no `remote`,
+ * no filesystem, no shell, and no privileged IPC. Capability is withheld
+ * rather than filtered, because a filter would have to distinguish UI code
+ * from notebook code and it cannot.
+ */
+
+const { shell } = require('electron');
+
+const { SCHEME, HOST } = require('./protocol');
+
+/**
+ * Schemes we are willing to hand to the operating system when the application
+ * asks to open something externally. `file:` is intentionally absent — an
+ * external `file:` open is a local-file disclosure/exec primitive.
+ */
+const EXTERNAL_SCHEMES = new Set(['https:', 'mailto:']);
+
+/**
+ * Decide whether a URL may be handed to the system browser.
+ * Exported so tests can assert the policy directly, without a live window.
+ */
+function isAllowedExternal(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (!EXTERNAL_SCHEMES.has(url.protocol)) return false;
+  // Defend against `https://evil/@` style confusion and credential-bearing URLs.
+  if (url.username || url.password) return false;
+  return true;
+}
+
+/**
+ * Is this URL part of the application itself?
+ * Only exact scheme+host app:// URLs count. Everything else is "somewhere else".
+ *
+ * This compares `protocol` and `hostname` rather than `origin` on purpose.
+ * `registerSchemesAsPrivileged({ standard: true })` teaches *Chromium* that
+ * `app:` is a standard scheme, but this function runs in the main process,
+ * which parses URLs with Node's implementation. Node has no such registry, so
+ * for a non-special scheme it reports `url.origin === 'null'`. Comparing
+ * origins here would therefore classify every in-app navigation as external
+ * and block the application from navigating within itself.
+ */
+function isAppUrl(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  return url.protocol === `${SCHEME}:` && url.hostname === HOST;
+}
+
+/**
+ * WebContents that already carry the policy. `app.on('web-contents-created')`
+ * and an explicit call at window-construction time can both target the same
+ * contents; without this guard the `will-navigate` listener would be attached
+ * twice and a single blocked navigation would open the system browser twice.
+ */
+const policyApplied = new WeakSet();
+
+/**
+ * Apply navigation/window/permission policy to a WebContents.
+ *
+ * `openExternal` is injected so tests can observe decisions without actually
+ * launching a browser; production uses `shell.openExternal`.
+ */
+function applyWebContentsPolicy(contents, options = {}) {
+  if (policyApplied.has(contents)) return contents;
+  policyApplied.add(contents);
+
+  const openExternal = options.openExternal || ((url) => shell.openExternal(url));
+  const log = options.log || (() => {});
+
+  // 1. Top-level navigation. The app is a single document; it may reload itself
+  //    and navigate within app://, but it may never navigate the shell window
+  //    to remote content. An http(s) link that would replace the app is instead
+  //    handed to the system browser.
+  contents.on('will-navigate', (event, url) => {
+    if (isAppUrl(url)) return; // in-app navigation and reloads are fine
+    event.preventDefault();
+    log('blocked-navigation', url);
+    if (isAllowedExternal(url)) {
+      openExternal(url);
+    }
+  });
+
+  // 2. Never allow the renderer to be redirected into a different origin.
+  contents.on('will-redirect', (event, url) => {
+    if (isAppUrl(url)) return;
+    event.preventDefault();
+    log('blocked-redirect', url);
+  });
+
+  // 3. New windows. SciREPL's external links are plain `target="_blank"`
+  //    anchors (www/index.html), so this handler *is* the external-link path.
+  //    No child BrowserWindow is ever created: approved links go to the OS
+  //    browser, everything else is denied.
+  contents.setWindowOpenHandler(({ url }) => {
+    if (isAllowedExternal(url)) {
+      log('external-open', url);
+      openExternal(url);
+    } else {
+      log('blocked-window-open', url);
+    }
+    return { action: 'deny' };
+  });
+
+  // 4. Refuse to attach any webview, and strip privileges if one is somehow
+  //    requested. `webviewTag` is already false, this is belt-and-braces.
+  contents.on('will-attach-webview', (event, webPreferences, params) => {
+    log('blocked-webview', params && params.src);
+    event.preventDefault();
+  });
+
+  // 5. Deny device/permission requests wholesale. SciREPL needs none of
+  //    geolocation, camera, microphone, MIDI, USB, serial, HID or
+  //    notifications for Phase 0. Anything it does need can be added here
+  //    deliberately rather than inherited by default.
+  const session = contents.session;
+  session.setPermissionRequestHandler((_wc, permission, callback) => {
+    log('denied-permission', permission);
+    callback(false);
+  });
+  session.setPermissionCheckHandler((_wc, permission) => {
+    log('denied-permission-check', permission);
+    return false;
+  });
+  session.setDevicePermissionHandler(() => false);
+
+  return contents;
+}
+
+module.exports = {
+  EXTERNAL_SCHEMES,
+  isAllowedExternal,
+  isAppUrl,
+  applyWebContentsPolicy,
+};

--- a/desktop/electron/test/artifact-boundary.test.mjs
+++ b/desktop/electron/test/artifact-boundary.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * artifact-boundary.test.mjs — the spike must contain only Free material.
+ *
+ * The brief is explicit that this Phase 0 shell may not carry Pro content, Pro
+ * feature flags, entitlement logic or commerce code. That is easy to state and
+ * easy to violate accidentally later (a profile default flipped, a bundled
+ * runtime added), so it is asserted here rather than left to review.
+ *
+ * The Free/Pro difference in this repository is concrete and checkable:
+ * build-profiles.json defines a `pro` profile whose only distinction is that it
+ * bundles the R/webR runtime offline (~50 MB) instead of loading it from a CDN.
+ * So "is this a Free artifact?" reduces to: the configured profile is not `pro`,
+ * and no offline R runtime is present in the tree the shell serves.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { launchShell, createReporter, waitForAppReady, REPO_ROOT, WWW_ROOT } from './harness.mjs';
+
+/** Recursively total a directory's size, or 0 if it does not exist. */
+function dirSize(dir) {
+  if (!existsSync(dir)) return 0;
+  let total = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    total += entry.isDirectory() ? dirSize(p) : statSync(p).size;
+  }
+  return total;
+}
+
+export default async function run() {
+  const r = createReporter('artifact-boundary');
+
+  /* ---------------- static checks on the served tree ---------------- */
+
+  const profiles = JSON.parse(readFileSync(path.join(REPO_ROOT, 'build-profiles.json'), 'utf8'));
+  const configured = readFileSync(path.join(WWW_ROOT, 'js', 'kernel_config.js'), 'utf8');
+  const profileMatch = configured.match(/["']?profile["']?\s*:\s*["']([^"']+)["']/);
+  const activeProfile = profileMatch ? profileMatch[1] : null;
+
+  r.log('a build profile is configured', activeProfile !== null, String(activeProfile));
+  r.log('the configured profile is not the Pro profile',
+    activeProfile !== 'pro', String(activeProfile));
+  r.log('the configured profile is one of the Free profiles',
+    ['mini', 'light', 'full'].includes(activeProfile), String(activeProfile));
+
+  // The Pro differentiator: R bundled offline.
+  const webrDir = path.join(WWW_ROOT, 'vendor', 'webr');
+  const webrBytes = dirSize(webrDir);
+  r.log('no offline R/webR runtime is bundled (that is the Pro profile)',
+    webrBytes === 0, webrBytes ? `${(webrBytes / 1e6).toFixed(1)} MB present` : 'absent');
+
+  const proBundled = (profiles.profiles?.pro?.bundle) || [];
+  r.log('build-profiles.json still describes Pro as the R-bundling profile',
+    proBundled.includes('r'), JSON.stringify(proBundled));
+
+  /* ---------------- no entitlement/commerce code in the shell ---------------- */
+
+  // Scan the shell's *source*, not its tests. `test/` is excluded because this
+  // very file necessarily contains the forbidden patterns as literals in order
+  // to search for them, and would otherwise match itself.
+  const shellDir = path.join(REPO_ROOT, 'desktop', 'electron');
+  const shellFiles = [];
+  (function walk(dir) {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (e.name === 'node_modules' || e.name === 'test') continue;
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (/\.(js|mjs|cjs)$/.test(e.name)) shellFiles.push(p);
+    }
+  })(shellDir);
+
+  r.log('shell source files were found to scan', shellFiles.length >= 4,
+    shellFiles.map(f => path.basename(f)).join(', '));
+
+  // Look for an *implemented* entitlement check, not a mention in a comment.
+  const forbidden = [
+    { re: /StoreContext\s*\.\s*GetAppLicenseAsync\s*\(/, what: 'Microsoft Store licence call' },
+    { re: /\bisPro\s*[:=]\s*(true|1)\b/, what: 'hardcoded isPro flag' },
+    { re: /requestPurchase|InAppPurchase|purchaseAppAsync/, what: 'commerce API call' },
+  ];
+  for (const { re, what } of forbidden) {
+    const hits = shellFiles.filter((f) => {
+      const src = readFileSync(f, 'utf8');
+      // Strip comments so documenting the future seam is allowed.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      return re.test(code);
+    });
+    r.log(`the shell source implements no ${what}`, hits.length === 0,
+      hits.map(f => path.relative(REPO_ROOT, f)).join(', '));
+  }
+
+  /* ---------------- runtime checks ---------------- */
+
+  const shell = await launchShell();
+  try {
+    await waitForAppReady(shell.page);
+
+    const dist = await shell.page.evaluate(() => window.sciREPLPlatform.getDistributionInfo());
+    r.log('the running shell reports the Free edition', dist.edition === 'free', JSON.stringify(dist));
+    r.log('the running shell reports no Store entitlement', dist.store === null);
+    r.log('the running shell reports a Free profile', dist.profile !== 'pro', dist.profile);
+
+    // R must still be *available* in Free — via CDN, not bundled.
+    const rSource = await shell.page.evaluate(() => {
+      const cfg = window.KERNEL_CONFIG || { languages: {} };
+      const r = cfg.languages.r || {};
+      return { enabled: !!r.enabled, runtime: r.runtime, localUrl: r.localUrl || null };
+    });
+    r.log('R is enabled in Free', rSource.enabled === true, JSON.stringify(rSource));
+    r.log('R is configured as a CDN runtime in Free, not a bundled one',
+      rSource.runtime === 'cdn', JSON.stringify(rSource));
+  } finally {
+    await shell.close();
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/download.test.mjs
+++ b/desktop/electron/test/download.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * download.test.mjs — the export/import plumbing under the packaged origin.
+ *
+ * Scope note: this does NOT re-test export *correctness*. The repository's
+ * existing browser tests (test_export.mjs, test_docx_math.mjs,
+ * test_latex_ipynb.mjs, test-export-workbook.mjs, …) already cover which bytes
+ * each format produces, and that logic is platform-independent — it runs in the
+ * same JavaScript on Android, the PWA and here.
+ *
+ * What Electron actually changes is the *delivery* step. In the browser,
+ * `FileIO._downloadBlob` creates a blob URL and clicks `<a download>`; the
+ * browser then writes the file. Inside a shell there is no browser download UI
+ * unless the main process participates, and blob URLs must be creatable from
+ * the custom origin at all. Those two things are what this file tests.
+ */
+
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { launchShell, createReporter, waitForAppReady } from './harness.mjs';
+
+export default async function run() {
+  const r = createReporter('download');
+  const downloadDir = mkdtempSync(path.join(tmpdir(), 'scirepl-dl-'));
+  const shell = await launchShell();
+
+  try {
+    const { page, electronApp } = shell;
+    await waitForAppReady(page);
+
+    /* --- blob URLs must work from the app:// origin --- */
+
+    const blobOk = await page.evaluate(async () => {
+      try {
+        const blob = new Blob(['hello-from-the-spike'], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const roundTrip = await (await fetch(url)).text();
+        URL.revokeObjectURL(url);
+        return { ok: roundTrip === 'hello-from-the-spike', scheme: url.split(':')[0] };
+      } catch (e) {
+        return { ok: false, error: String(e && e.message) };
+      }
+    });
+    r.log('blob URLs are creatable and readable under app://',
+      blobOk.ok === true, JSON.stringify(blobOk));
+
+    /* --- an <a download> click must reach the main process --- */
+
+    // Auto-accept downloads into a scratch directory so the assertion does not
+    // depend on a native Save dialog. This mirrors what a real shell must do:
+    // with no will-download participant, Electron shows a modal Save dialog —
+    // which, in a headless test, blocks the main process message loop and wedges
+    // every later electronApp.evaluate() call.
+    //
+    // The handler therefore must not throw. Note `require` is NOT in scope
+    // inside electronApp.evaluate, so the path is joined with plain string
+    // concatenation (forward slashes are valid on Windows too), and the whole
+    // body is wrapped so that any error still results in a save path being set.
+    await electronApp.evaluate(async ({ session }, dir) => {
+      globalThis.__spikeDownloads = [];
+      const base = String(dir).replace(/[\\/]+$/, '');
+      session.defaultSession.on('will-download', (_event, item) => {
+        let target = `${base}/download.bin`;
+        try {
+          target = `${base}/${item.getFilename()}`;
+        } catch { /* keep the fallback */ }
+        // Always set a path, even on error, so no modal dialog can appear.
+        item.setSavePath(target);
+        item.once('done', (_e, state) => {
+          try {
+            globalThis.__spikeDownloads.push({
+              filename: item.getFilename(),
+              state,
+              path: target,
+              bytes: item.getReceivedBytes(),
+            });
+          } catch { /* ignore */ }
+        });
+      });
+    }, downloadDir);
+
+    // Drive the application's own download helper rather than a hand-rolled
+    // anchor, so the test exercises the code path exports actually use.
+    const triggered = await page.evaluate(async () => {
+      const io = window.fileIO;
+      if (!io || typeof io._downloadBlob !== 'function') return { available: false };
+      const blob = new Blob(['# spike\n\nexported from the Electron shell\n'], { type: 'text/markdown' });
+      await io._downloadBlob(blob, 'spike-export.md');
+      return { available: true };
+    });
+    r.log('FileIO._downloadBlob is the shared browser path (no Capacitor here)',
+      triggered.available === true, JSON.stringify(triggered));
+
+    // Give the download a moment to complete. Each probe of the main process is
+    // bounded: if a modal dialog ever does appear, the main process stops
+    // servicing evaluate() and this must fail the test rather than hang it.
+    const deadline = Date.now() + 20_000;
+    let recorded = [];
+    let mainProcessBlocked = false;
+    while (Date.now() < deadline) {
+      try {
+        recorded = await Promise.race([
+          electronApp.evaluate(() => globalThis.__spikeDownloads || []),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('main process did not respond')), 5_000)),
+        ]);
+      } catch {
+        mainProcessBlocked = true;
+        break;
+      }
+      if (recorded.length > 0) break;
+      await page.waitForTimeout(250);
+    }
+    r.log('main process stayed responsive during the download (no modal dialog)',
+      mainProcessBlocked === false,
+      mainProcessBlocked ? 'evaluate() stopped responding — a native dialog is probably blocking' : '');
+
+    const done = recorded.find(d => d.filename === 'spike-export.md');
+    r.log('an application download reaches the main process',
+      Boolean(done), JSON.stringify(recorded));
+    r.log('the download completes successfully',
+      done && done.state === 'completed', done && done.state);
+
+    if (done && existsSync(done.path)) {
+      const content = readFileSync(done.path, 'utf8');
+      r.log('downloaded bytes are intact on disk',
+        content.includes('exported from the Electron shell'), `${content.length} bytes`);
+    } else {
+      r.log('downloaded bytes are intact on disk', false, 'file not written');
+    }
+
+    /* --- import: the file input path the app uses --- */
+
+    const importOk = await page.evaluate(async () => {
+      // DataTransfer + File is how a chosen file arrives; verify the renderer
+      // can construct and read one under this origin (FileReader + File API).
+      try {
+        const file = new File([JSON.stringify({ cells: [], metadata: {} })],
+          'spike.ipynb', { type: 'application/json' });
+        const text = await file.text();
+        return { ok: JSON.parse(text) && file.name === 'spike.ipynb', size: file.size };
+      } catch (e) {
+        return { ok: false, error: String(e && e.message) };
+      }
+    });
+    r.log('File/FileReader import primitives work under app://',
+      importOk.ok === true, JSON.stringify(importOk));
+
+    /* --- window.print must not crash the shell (PDF export fallback) --- */
+
+    const printSafe = await page.evaluate(() => {
+      // Electron's print in a sandboxed renderer is async and must not throw
+      // synchronously; we only assert it is callable and the page survives.
+      return typeof window.print === 'function';
+    });
+    r.log('window.print is available for the PDF export fallback', printSafe === true);
+    r.log('renderer is still responsive after the download',
+      (await page.evaluate(() => 1 + 1)) === 2);
+  } finally {
+    await shell.close();
+    try { rmSync(downloadDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/download.test.mjs
+++ b/desktop/electron/test/download.test.mjs
@@ -59,10 +59,14 @@ export default async function run() {
     await electronApp.evaluate(async ({ session }, dir) => {
       globalThis.__spikeDownloads = [];
       const base = String(dir).replace(/[\\/]+$/, '');
+      // Use the separator the directory itself is written with, so a Windows
+      // temp path (C:\Users\...\Temp\x) does not end up with a mixed-separator
+      // save path. `require('path')` is not in scope inside this evaluate.
+      const sep = base.includes('\\') ? '\\' : '/';
       session.defaultSession.on('will-download', (_event, item) => {
-        let target = `${base}/download.bin`;
+        let target = `${base}${sep}download.bin`;
         try {
-          target = `${base}/${item.getFilename()}`;
+          target = `${base}${sep}${item.getFilename()}`;
         } catch { /* keep the fallback */ }
         // Always set a path, even on error, so no modal dialog can appear.
         item.setSavePath(target);

--- a/desktop/electron/test/fixtures/electron-stub.cjs
+++ b/desktop/electron/test/fixtures/electron-stub.cjs
@@ -1,0 +1,34 @@
+/**
+ * electron-stub.cjs — minimal stand-in for the `electron` module.
+ *
+ * policy.unit.test.mjs exercises the shell's pure decision functions
+ * (resolveRequestPath, isAllowedExternal, isAppUrl, buildCsp, assertNullary)
+ * without launching Electron, so those modules' top-level `require('electron')`
+ * needs something with the right shape. Nothing here is ever invoked by the
+ * functions under test; any call is a bug in the test, so the members throw
+ * loudly rather than silently returning undefined.
+ */
+
+function unavailable(name) {
+  return new Proxy(function () {}, {
+    apply() {
+      throw new Error(`electron.${name} was called from a unit test; it is not available outside Electron`);
+    },
+    get(_t, prop) {
+      if (prop === 'then') return undefined; // don't look like a thenable
+      throw new Error(`electron.${name}.${String(prop)} was accessed from a unit test`);
+    },
+  });
+}
+
+module.exports = {
+  app: unavailable('app'),
+  shell: unavailable('shell'),
+  protocol: unavailable('protocol'),
+  net: unavailable('net'),
+  ipcMain: unavailable('ipcMain'),
+  session: unavailable('session'),
+  BrowserWindow: unavailable('BrowserWindow'),
+  contextBridge: unavailable('contextBridge'),
+  ipcRenderer: unavailable('ipcRenderer'),
+};

--- a/desktop/electron/test/harness.mjs
+++ b/desktop/electron/test/harness.mjs
@@ -139,7 +139,19 @@ export async function startDevServer() {
 /** Launch plain Chromium against the dev server — the comparison baseline. */
 export async function launchBrowserBaseline() {
   const server = await startDevServer();
-  const browser = await chromium.launch({ headless: true });
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch (err) {
+    server.stop();
+    // `npm install` installs the Playwright package but not its browser
+    // binaries. Say so plainly instead of surfacing Playwright's stack.
+    throw new Error(
+      'Could not launch Chromium for the browser baseline. Playwright browser ' +
+      'binaries are not provisioned by `npm install` — run `npx playwright install chromium`.\n' +
+      `Original error: ${err && err.message}`
+    );
+  }
   const context = await browser.newContext();
   await primeContext(context);
   const page = await context.newPage();

--- a/desktop/electron/test/harness.mjs
+++ b/desktop/electron/test/harness.mjs
@@ -1,0 +1,180 @@
+/**
+ * harness.mjs — shared test plumbing for the Electron shell.
+ *
+ * The point of this file is that the *probes* (test/probes/*.mjs) never learn
+ * whether they are driving an Electron window or a plain Chromium page. Both
+ * runners hand them a Playwright `Page`, so the same assertions produce a
+ * genuine A/B comparison between the browser baseline and the packaged origin.
+ */
+
+import { _electron as electron, chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Reporting and path constants live in reporter.mjs, which imports nothing.
+// Re-exported here so the Electron-driven suites have a single import.
+export { createReporter, ELECTRON_DIR, REPO_ROOT, WWW_ROOT, APP_ORIGIN } from './reporter.mjs';
+import { ELECTRON_DIR, REPO_ROOT, WWW_ROOT } from './reporter.mjs';
+
+/* ------------------------------------------------------------------ */
+/* Electron                                                            */
+/* ------------------------------------------------------------------ */
+
+function electronBinary() {
+  const p = path.join(ELECTRON_DIR, 'node_modules', 'electron');
+  if (!existsSync(p)) {
+    throw new Error(
+      'Electron is not installed. Run `npm --prefix desktop/electron install` first.'
+    );
+  }
+  return p;
+}
+
+/**
+ * Launch the shell.
+ *
+ * @param {object} opts
+ * @param {string} [opts.userDataDir] persist storage here (for restart tests).
+ *                                    Omit to get a throwaway profile.
+ * @param {boolean} [opts.keepUserData] don't delete the profile on close.
+ * @param {boolean} [opts.prime=true] grant the privacy + auto-download consents
+ *   before exercising kernels, matching what the repo's existing browser tests
+ *   do. Without this, `KernelManager` opens a confirmation modal and awaits a
+ *   click before fetching any CDN runtime, so CDN-backed kernels appear to hang
+ *   rather than fail — pass `prime: false` only when testing that gate itself.
+ */
+export async function launchShell(opts = {}) {
+  const userDataDir = opts.userDataDir || mkdtempSync(path.join(tmpdir(), 'scirepl-electron-'));
+  const ownsUserData = !opts.userDataDir && !opts.keepUserData;
+
+  const args = [ELECTRON_DIR];
+  // WSL/CI containers frequently lack a usable setuid sandbox helper. We only
+  // relax this when explicitly asked, and every security probe records whether
+  // it ran with the sandbox on so the report cannot overclaim.
+  if (process.env.SCIREPL_ELECTRON_NO_SANDBOX === '1') args.push('--no-sandbox');
+
+  const electronApp = await electron.launch({
+    executablePath: path.join(electronBinary(), 'dist', 'electron'),
+    args,
+    env: {
+      ...process.env,
+      SCIREPL_USER_DATA: userDataDir,
+      SCIREPL_WWW: opts.www || WWW_ROOT,
+      ELECTRON_ENABLE_LOGGING: '1',
+    },
+    timeout: 120_000,
+  });
+
+  const page = await electronApp.firstWindow({ timeout: 120_000 });
+
+  if (opts.prime !== false) {
+    // localStorage is per-origin, so it must be written from a loaded document
+    // and then picked up by a reload. This is also, incidentally, a reload test.
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate(() => {
+      localStorage.setItem('scirepl_privacy_accepted', '1');
+      localStorage.setItem('scirepl_auto_download', '1');
+    });
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+  }
+
+  return {
+    electronApp,
+    page,
+    userDataDir,
+    /**
+     * Close the shell. A graceful close is attempted first because that is the
+     * path a real user takes and the one the persistence tests depend on, but
+     * it is bounded: a shell that refuses to exit must fail the test rather
+     * than wedge the whole suite.
+     */
+    async close({ graceful = true, timeoutMs = 20_000 } = {}) {
+      let timedOut = false;
+      if (graceful) {
+        const closed = electronApp.close().then(() => true).catch(() => true);
+        const timer = new Promise(res => setTimeout(() => { timedOut = true; res(false); }, timeoutMs));
+        await Promise.race([closed, timer]);
+      }
+      if (timedOut || !graceful) {
+        try { electronApp.process().kill('SIGKILL'); } catch { /* already gone */ }
+      }
+      if (ownsUserData) {
+        try { rmSync(userDataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+      return { timedOut };
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Browser baseline                                                    */
+/* ------------------------------------------------------------------ */
+
+const DEV_SERVER_PORT = Number(process.env.SCIREPL_TEST_PORT) || 8085;
+
+/** Start the repo's own dev server (server.js) so the baseline is the real one. */
+export async function startDevServer() {
+  const proc = spawn(process.execPath, [path.join(REPO_ROOT, 'server.js')], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, PORT: String(DEV_SERVER_PORT) },
+    stdio: 'ignore',
+  });
+  // Poll until it answers rather than sleeping a fixed amount.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://localhost:${DEV_SERVER_PORT}/index.html`);
+      if (res.ok) break;
+    } catch { /* not up yet */ }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return {
+    url: `http://localhost:${DEV_SERVER_PORT}`,
+    stop() { try { proc.kill('SIGTERM'); } catch { /* ignore */ } },
+  };
+}
+
+/** Launch plain Chromium against the dev server — the comparison baseline. */
+export async function launchBrowserBaseline() {
+  const server = await startDevServer();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  await primeContext(context);
+  const page = await context.newPage();
+  await page.goto(`${server.url}/index.html`, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+  return {
+    page,
+    origin: server.url,
+    async close() {
+      await browser.close().catch(() => {});
+      server.stop();
+    },
+  };
+}
+
+/**
+ * The app gates startup behind a privacy prompt and an auto-download opt-in.
+ * The existing browser tests set the same two keys, so both runners start from
+ * the same application state.
+ */
+export async function primeContext(context) {
+  await context.addInitScript(() => {
+    localStorage.setItem('scirepl_privacy_accepted', '1');
+    localStorage.setItem('scirepl_auto_download', '1');
+  });
+}
+
+/** Wait until the app's kernel manager exists and the UI has booted. */
+export async function waitForAppReady(page, timeout = 120_000) {
+  await page.waitForFunction(() => !!window.kernelManager, null, { timeout });
+}
+
+/** Collect console + page errors for diagnosis. */
+export function attachLogs(page) {
+  const logs = [];
+  page.on('console', m => logs.push(`[${m.type()}] ${m.text()}`));
+  page.on('pageerror', e => logs.push(`[pageerror] ${e.message}`));
+  return logs;
+}

--- a/desktop/electron/test/harness.mjs
+++ b/desktop/electron/test/harness.mjs
@@ -9,7 +9,8 @@
 
 import { _electron as electron, chromium } from 'playwright';
 import { spawn } from 'node:child_process';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -22,14 +23,60 @@ import { ELECTRON_DIR, REPO_ROOT, WWW_ROOT } from './reporter.mjs';
 /* Electron                                                            */
 /* ------------------------------------------------------------------ */
 
-function electronBinary() {
-  const p = path.join(ELECTRON_DIR, 'node_modules', 'electron');
-  if (!existsSync(p)) {
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Absolute path to the Electron executable for THIS platform.
+ *
+ * The executable name is platform-specific — `electron` on Linux,
+ * `electron.exe` on Windows, `Electron.app/Contents/MacOS/Electron` on macOS —
+ * so it must never be hardcoded. (It was, and the first Windows CI run failed
+ * with Playwright's opaque "Process failed to launch!" because
+ * `dist/electron` does not exist there.)
+ *
+ * The `electron` package already solves this: its entry point exports the
+ * absolute path, resolved from the `path.txt` its installer writes. Ask the
+ * package rather than guessing, and fall back to reading `path.txt` directly if
+ * the entry point is unavailable.
+ *
+ * Playwright cannot resolve this itself here: Electron lives in
+ * `desktop/electron/node_modules`, deliberately isolated from the root
+ * dependency tree, so `executablePath` must be passed explicitly.
+ */
+function electronExecutable() {
+  const pkgDir = path.join(ELECTRON_DIR, 'node_modules', 'electron');
+  if (!existsSync(pkgDir)) {
     throw new Error(
       'Electron is not installed. Run `npm --prefix desktop/electron install` first.'
     );
   }
-  return p;
+
+  let exe;
+  try {
+    // electron/index.js exports the absolute path to the binary.
+    exe = requireFromHere(pkgDir);
+  } catch (err) {
+    try {
+      const rel = readFileSync(path.join(pkgDir, 'path.txt'), 'utf8').trim();
+      exe = path.join(pkgDir, 'dist', rel);
+    } catch {
+      throw new Error(
+        `Could not determine the Electron executable path under ${pkgDir}. ` +
+        'The install may have been run with --ignore-scripts, which skips the ' +
+        'binary download. Re-run `npm --prefix desktop/electron install`.\n' +
+        `Original error: ${err && err.message}`
+      );
+    }
+  }
+
+  if (typeof exe !== 'string' || !existsSync(exe)) {
+    throw new Error(
+      `The Electron executable was not found at ${exe}. ` +
+      'The binary download may have been skipped (ELECTRON_SKIP_BINARY_DOWNLOAD / ' +
+      '--ignore-scripts). Re-run `npm --prefix desktop/electron install`.'
+    );
+  }
+  return exe;
 }
 
 /**
@@ -55,17 +102,39 @@ export async function launchShell(opts = {}) {
   // it ran with the sandbox on so the report cannot overclaim.
   if (process.env.SCIREPL_ELECTRON_NO_SANDBOX === '1') args.push('--no-sandbox');
 
-  const electronApp = await electron.launch({
-    executablePath: path.join(electronBinary(), 'dist', 'electron'),
-    args,
-    env: {
-      ...process.env,
-      SCIREPL_USER_DATA: userDataDir,
-      SCIREPL_WWW: opts.www || WWW_ROOT,
-      ELECTRON_ENABLE_LOGGING: '1',
-    },
-    timeout: 120_000,
-  });
+  const executablePath = electronExecutable();
+  let electronApp;
+  try {
+    electronApp = await electron.launch({
+      executablePath,
+      args,
+      env: {
+        ...process.env,
+        SCIREPL_USER_DATA: userDataDir,
+        SCIREPL_WWW: opts.www || WWW_ROOT,
+        ELECTRON_ENABLE_LOGGING: '1',
+      },
+      timeout: 120_000,
+    });
+  } catch (err) {
+    // Playwright reports launch failures as a bare "Process failed to launch!"
+    // with no indication of what it tried to run. Attach the details that
+    // actually narrow it down — this is what the first Windows CI failure
+    // needed and did not have.
+    throw new Error(
+      `Failed to launch the Electron shell.\n` +
+      `  executable: ${executablePath}\n` +
+      `  args:       ${JSON.stringify(args)}\n` +
+      `  platform:   ${process.platform}-${process.arch}\n` +
+      `  www root:   ${opts.www || WWW_ROOT}\n` +
+      `  userData:   ${userDataDir}\n` +
+      `If the executable path looks wrong for this platform, the Electron install ` +
+      `is incomplete. If it looks right, the main process most likely threw during ` +
+      `startup — run it directly to see the error:\n` +
+      `  npm --prefix desktop/electron start\n` +
+      `Original error: ${err && err.message}`
+    );
+  }
 
   const page = await electronApp.firstWindow({ timeout: 120_000 });
 

--- a/desktop/electron/test/kernels.test.mjs
+++ b/desktop/electron/test/kernels.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * kernels.test.mjs — the compatibility matrix.
+ *
+ * Runs probes/kernels.mjs inside the Electron shell. With
+ * `SCIREPL_COMPARE_BASELINE=1` it runs the identical probes in plain Chromium
+ * against the repo's dev server too, and reports both columns, so a kernel that
+ * is broken everywhere is not mistaken for a kernel that Electron broke.
+ *
+ * Results are written to desktop/electron/test/results/kernel-matrix.json so
+ * the feasibility report can quote measured numbers rather than impressions.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  launchShell, launchBrowserBaseline, createReporter, waitForAppReady, attachLogs,
+} from './harness.mjs';
+import {
+  KERNEL_CASES, runKernel, enabledKernels, registeredKernels, probeSharedVfs, probeIndexedDb,
+} from './probes/kernels.mjs';
+
+const RESULTS_DIR = fileURLToPath(new URL('./results', import.meta.url));
+
+/**
+ * Run the full probe set against one already-loaded page.
+ *
+ * Each kernel yields two separate verdicts, because they answer different
+ * questions:
+ *   - "runs" — did the runtime initialise and execute without error? This is
+ *     the feasibility question, and it is always a hard pass/fail.
+ *   - "output" — did it produce the expected value? This is application
+ *     behaviour. Where a case is marked `knownIssue`, a failure here is
+ *     reported as a known gap rather than a shell failure — but only because
+ *     the parity check separately proves Electron matches the browser.
+ */
+async function collect(page, label, r, { enabled }) {
+  const rows = [];
+  for (const kase of KERNEL_CASES) {
+    if (!enabled.includes(kase.lang)) {
+      r.skip(`${label}: ${kase.label}`, 'not enabled in this build profile');
+      rows.push({ ...kase, expect: String(kase.expect), status: 'disabled' });
+      continue;
+    }
+
+    const res = await runKernel(page, kase);
+    const ran = res.status === 'ok';
+    const outputOk = ran && kase.expect.test(res.output || '');
+
+    r.log(`${label}: ${kase.label} — initialises and executes`, ran,
+      ran ? `init ${res.initMs}ms, exec ${res.execMs}ms`
+          : `${res.status} ${res.error || ''}`);
+
+    if (outputOk || !kase.knownIssue) {
+      r.log(`${label}: ${kase.label} — produces expected output`, outputOk,
+        outputOk ? '' : `output=${JSON.stringify(res.output || '')}`);
+    } else {
+      r.skip(`${label}: ${kase.label} — produces expected output`,
+        `known pre-existing gap: ${kase.knownIssue}`);
+    }
+
+    rows.push({ ...kase, expect: String(kase.expect), ...res, ran, outputOk, passed: outputOk });
+  }
+  return rows;
+}
+
+export default async function run() {
+  const r = createReporter('kernels');
+  mkdirSync(RESULTS_DIR, { recursive: true });
+
+  const shell = await launchShell();
+  const logs = attachLogs(shell.page);
+  const report = { generatedAt: new Date().toISOString(), electron: null, browser: null };
+
+  try {
+    await waitForAppReady(shell.page);
+
+    const enabled = await enabledKernels(shell.page);
+    const registered = await registeredKernels(shell.page);
+    r.log('build profile enables the expected Free kernel set',
+      enabled.length > 0, `enabled=${enabled.join(',')}`);
+    r.log('every enabled kernel is registered with the kernel manager',
+      enabled.every(l => registered.includes(l)),
+      `registered=${registered.join(',')}`);
+
+    const startupMs = await shell.page.evaluate(() => {
+      const nav = performance.getEntriesByType('navigation')[0];
+      return nav ? Math.round(nav.domContentLoadedEventEnd) : null;
+    });
+    r.log('startup measured', typeof startupMs === 'number', `DOMContentLoaded ${startupMs}ms`);
+
+    report.electron = {
+      origin: shell.page.url(),
+      enabled,
+      registered,
+      startupMs,
+      kernels: await collect(shell.page, 'electron', r, { enabled }),
+      sharedVfs: await probeSharedVfs(shell.page),
+      indexedDb: await probeIndexedDb(shell.page),
+    };
+
+    r.log('electron: SharedVFS round-trips in memory',
+      report.electron.sharedVfs.roundTrip === true, JSON.stringify(report.electron.sharedVfs));
+    r.log('electron: SharedVFS content is visible to the Python kernel',
+      report.electron.sharedVfs.visibleToPython === true,
+      report.electron.sharedVfs.pythonError || '');
+    r.log('electron: SharedVFS persisted to IndexedDB',
+      report.electron.sharedVfs.savedToIndexedDb === true);
+    r.log('electron: IndexedDB is usable and enumerable',
+      report.electron.indexedDb.supported === true,
+      JSON.stringify(report.electron.indexedDb));
+
+    const pageErrors = logs.filter(l => l.startsWith('[pageerror]'));
+    r.log('no uncaught page errors while exercising kernels',
+      pageErrors.length === 0, pageErrors.slice(0, 3).join(' | '));
+  } finally {
+    await shell.close();
+  }
+
+  /* ---------------- optional browser baseline ---------------- */
+
+  if (process.env.SCIREPL_COMPARE_BASELINE === '1') {
+    const baseline = await launchBrowserBaseline();
+    try {
+      await waitForAppReady(baseline.page);
+      const enabled = await enabledKernels(baseline.page);
+      report.browser = {
+        origin: baseline.origin,
+        enabled,
+        kernels: await collect(baseline.page, 'browser', r, { enabled }),
+        sharedVfs: await probeSharedVfs(baseline.page),
+        indexedDb: await probeIndexedDb(baseline.page),
+      };
+    } finally {
+      await baseline.close();
+    }
+
+    // The comparison is the point: flag only kernels where the two disagree.
+    const byLang = Object.fromEntries((report.browser.kernels || []).map(k => [k.lang, k]));
+    for (const e of report.electron.kernels) {
+      const b = byLang[e.lang];
+      if (!b) continue;
+      if (e.status === 'disabled' && b.status === 'disabled') continue;
+      // Compare both verdicts. This is what licenses treating a `knownIssue`
+      // as pre-existing: if Electron ever diverges from the browser — in either
+      // direction — this fails regardless of the knownIssue marking.
+      const same = Boolean(e.ran) === Boolean(b.ran) && Boolean(e.outputOk) === Boolean(b.outputOk);
+      r.log(`parity with browser baseline: ${e.label}`, same,
+        `electron(ran=${!!e.ran},output=${!!e.outputOk}) browser(ran=${!!b.ran},output=${!!b.outputOk})`);
+    }
+  } else {
+    r.skip('browser baseline comparison', 'set SCIREPL_COMPARE_BASELINE=1 to run it');
+  }
+
+  writeFileSync(path.join(RESULTS_DIR, 'kernel-matrix.json'), JSON.stringify(report, null, 2));
+  console.log(`\n  results written to ${path.join(RESULTS_DIR, 'kernel-matrix.json')}`);
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/measure.mjs
+++ b/desktop/electron/test/measure.mjs
@@ -1,0 +1,129 @@
+/**
+ * measure.mjs — startup, memory and size measurements for the feasibility report.
+ *
+ * This is a measurement tool, not a pass/fail test, so it is not part of
+ * run-all.mjs. Run it explicitly:
+ *
+ *   node desktop/electron/test/measure.mjs
+ *   node desktop/electron/test/measure.mjs --with-python
+ *
+ * Numbers are written to test/results/measurements.json. They are specific to
+ * the machine that produced them — quote them with the platform attached.
+ */
+
+import { existsSync, readdirSync, statSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { launchShell, waitForAppReady, WWW_ROOT, ELECTRON_DIR, REPO_ROOT } from './harness.mjs';
+import { runKernel, KERNEL_CASES } from './probes/kernels.mjs';
+
+const RESULTS_DIR = fileURLToPath(new URL('./results', import.meta.url));
+
+function dirSize(dir) {
+  if (!existsSync(dir)) return 0;
+  let total = 0;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    total += e.isDirectory() ? dirSize(p) : statSync(p).size;
+  }
+  return total;
+}
+
+const mb = (bytes) => Number((bytes / 1e6).toFixed(1));
+
+const withPython = process.argv.includes('--with-python');
+
+/* ---------------- static sizes ---------------- */
+
+const sizes = {
+  wwwTotalMB: mb(dirSize(WWW_ROOT)),
+  wwwVendorMB: mb(dirSize(path.join(WWW_ROOT, 'vendor'))),
+  electronRuntimeMB: mb(dirSize(path.join(ELECTRON_DIR, 'node_modules', 'electron', 'dist'))),
+  shellSourceKB: Number((dirSize(path.join(REPO_ROOT, 'desktop', 'electron')) -
+    dirSize(path.join(REPO_ROOT, 'desktop', 'electron', 'node_modules'))) / 1e3).toFixed(1),
+  perVendor: {},
+};
+const vendorDir = path.join(WWW_ROOT, 'vendor');
+if (existsSync(vendorDir)) {
+  for (const e of readdirSync(vendorDir, { withFileTypes: true })) {
+    if (e.isDirectory()) sizes.perVendor[e.name] = mb(dirSize(path.join(vendorDir, e.name)));
+  }
+}
+
+console.log('--- sizes ---');
+console.log(`  prepared www/            ${sizes.wwwTotalMB} MB (vendor: ${sizes.wwwVendorMB} MB)`);
+console.log(`  Electron runtime (dist)  ${sizes.electronRuntimeMB} MB  [this platform only]`);
+console.log(`  shell source             ${sizes.shellSourceKB} kB`);
+for (const [k, v] of Object.entries(sizes.perVendor)) console.log(`    vendor/${k.padEnd(12)} ${v} MB`);
+
+/* ---------------- runtime measurements ---------------- */
+
+const t0 = Date.now();
+const shell = await launchShell();
+const launchMs = Date.now() - t0;
+
+await waitForAppReady(shell.page);
+const readyMs = Date.now() - t0;
+
+const nav = await shell.page.evaluate(() => {
+  const n = performance.getEntriesByType('navigation')[0];
+  if (!n) return null;
+  return {
+    domContentLoadedMs: Math.round(n.domContentLoadedEventEnd),
+    loadEventMs: Math.round(n.loadEventEnd),
+    responseEndMs: Math.round(n.responseEnd),
+  };
+});
+
+/** Aggregate Electron's own per-process metrics. */
+async function metrics(label) {
+  const raw = await shell.electronApp.evaluate(({ app }) => app.getAppMetrics());
+  const byType = {};
+  let totalKB = 0;
+  for (const m of raw) {
+    const kb = (m.memory && m.memory.workingSetSize) || 0;
+    byType[m.type] = (byType[m.type] || 0) + kb;
+    totalKB += kb;
+  }
+  const out = {
+    label,
+    processCount: raw.length,
+    totalMB: Number((totalKB / 1024).toFixed(1)),
+    byTypeMB: Object.fromEntries(Object.entries(byType).map(([k, v]) => [k, Number((v / 1024).toFixed(1))])),
+  };
+  console.log(`  ${label.padEnd(22)} ${out.totalMB} MB across ${out.processCount} processes  ${JSON.stringify(out.byTypeMB)}`);
+  return out;
+}
+
+console.log('\n--- startup ---');
+console.log(`  process launch -> first window   ${launchMs} ms`);
+console.log(`  process launch -> app ready      ${readyMs} ms`);
+if (nav) console.log(`  DOMContentLoaded (in page)       ${nav.domContentLoadedMs} ms`);
+
+console.log('\n--- memory ---');
+const memIdle = await metrics('idle (app loaded)');
+
+const kernelMem = [];
+if (withPython) {
+  const python = KERNEL_CASES.find(k => k.lang === 'python');
+  const res = await runKernel(shell.page, python);
+  console.log(`  python init ${res.initMs} ms, exec ${res.execMs} ms`);
+  kernelMem.push({ kernel: 'python', ...res, metrics: await metrics('after Pyodide') });
+} else {
+  console.log('  (pass --with-python to measure memory with a WASM kernel loaded)');
+}
+
+await shell.close();
+
+mkdirSync(RESULTS_DIR, { recursive: true });
+const report = {
+  generatedAt: new Date().toISOString(),
+  platform: `${process.platform}-${process.arch}`,
+  note: 'Measured on the machine named above. Windows figures must be re-measured on Windows.',
+  sizes,
+  startup: { launchToFirstWindowMs: launchMs, launchToAppReadyMs: readyMs, navigation: nav },
+  memory: { idle: memIdle, kernels: kernelMem },
+};
+writeFileSync(path.join(RESULTS_DIR, 'measurements.json'), JSON.stringify(report, null, 2));
+console.log(`\nwritten to ${path.join(RESULTS_DIR, 'measurements.json')}`);
+process.exit(0);

--- a/desktop/electron/test/offline.test.mjs
+++ b/desktop/electron/test/offline.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * offline.test.mjs — does the shell still work with no network?
+ *
+ * This matters more for a packaged desktop application than for the PWA: a
+ * Store user may launch it offline on day one. The Free `full` profile bundles
+ * Bash, ClojureScript, SWI-Prolog and Python locally and leaves Lua and R on a
+ * CDN, so the expected offline result is *partial*: the bundled kernels must
+ * work with no network at all, and the CDN kernels must fail cleanly rather
+ * than hang or corrupt the application.
+ *
+ * Network is cut at the session level in the main process, which is a truer
+ * simulation than toggling `navigator.onLine` in the renderer.
+ */
+
+import { launchShell, createReporter, waitForAppReady } from './harness.mjs';
+import { KERNEL_CASES, runKernel } from './probes/kernels.mjs';
+
+export default async function run() {
+  const r = createReporter('offline');
+  const shell = await launchShell();
+
+  try {
+    const { page, electronApp } = shell;
+    await waitForAppReady(page);
+
+    // Cut the network by pointing http/https at a dead proxy.
+    //
+    // An earlier revision used `webRequest.onBeforeRequest` and cancelled
+    // everything that was not `app://`. That broke the application itself:
+    // installing a webRequest handler routes custom-protocol requests through
+    // the network delegate too, and even returning `{cancel: false}` for
+    // `app://` URLs made them fail with net::ERR_UNEXPECTED, so the page could
+    // no longer reload. A proxy only affects http/https, leaving the custom
+    // scheme served entirely by protocol.handle() — which is both a truer
+    // simulation of "no network" and harmless to the app origin.
+    const blocked = await electronApp.evaluate(async ({ session }) => {
+      await session.defaultSession.setProxy({ proxyRules: 'http=127.0.0.1:1;https=127.0.0.1:1' });
+      await session.defaultSession.closeAllConnections();
+      return true;
+    });
+    r.log('network cut for the offline run (http/https proxied to a dead port)', blocked === true);
+
+    // Sanity: a remote request really is refused now.
+    const remote = await page.evaluate(async () => {
+      try {
+        await fetch('https://cdn.jsdelivr.net/npm/scittle@0.6.22/dist/scittle.js', { cache: 'no-store' });
+        return 'reachable';
+      } catch {
+        return 'blocked';
+      }
+    });
+    r.log('remote origins are unreachable during the offline run', remote === 'blocked', remote);
+
+    // The application itself must still load and reload from local assets.
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+    await waitForAppReady(page);
+    r.log('application still starts and reloads with no network', true);
+
+    const localAsset = await page.evaluate(async () => {
+      const res = await fetch('js/kernel_config.js');
+      return res.ok;
+    });
+    r.log('local app:// assets still load with no network', localAsset === true);
+
+    // Bundled kernels must work offline.
+    const offlineCapable = KERNEL_CASES.filter(k => !k.network);
+    for (const kase of offlineCapable) {
+      const res = await runKernel(page, kase, 120_000);
+      const ran = res.status === 'ok';
+      r.log(`offline: ${kase.label} still runs`, ran,
+        ran ? `init ${res.initMs}ms` : `${res.status} ${res.error || ''}`);
+      if (ran && !kase.knownIssue) {
+        r.log(`offline: ${kase.label} still produces expected output`,
+          kase.expect.test(res.output || ''), JSON.stringify(res.output || ''));
+      }
+    }
+
+    // CDN-backed kernels must fail cleanly, not hang or wedge the app.
+    const cdnCase = KERNEL_CASES.find(k => k.lang === 'lua');
+    const cdnRes = await runKernel(page, cdnCase, 60_000);
+    r.log('offline: a CDN-only kernel fails rather than succeeding silently',
+      cdnRes.status !== 'ok', `${cdnRes.status} ${cdnRes.error || ''}`.slice(0, 200));
+
+    // And the application must survive that failure.
+    const alive = await page.evaluate(() => ({
+      responsive: 1 + 1 === 2,
+      kernelManager: !!window.kernelManager,
+      vfs: !!window.sharedVFS,
+    }));
+    r.log('application remains responsive after an offline kernel failure',
+      alive.responsive && alive.kernelManager && alive.vfs, JSON.stringify(alive));
+
+    // A bundled kernel must still work after the failed one.
+    const afterFailure = await runKernel(page, KERNEL_CASES.find(k => k.lang === 'bash'), 120_000);
+    r.log('a bundled kernel still runs after a CDN kernel failed offline',
+      afterFailure.status === 'ok', `${afterFailure.status} ${afterFailure.error || ''}`);
+  } finally {
+    await shell.close();
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/persistence.test.mjs
+++ b/desktop/electron/test/persistence.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * persistence.test.mjs — does application state survive a real restart?
+ *
+ * This launches the shell, writes notebook and SharedVFS state, quits the
+ * process for real, relaunches against the same userData directory, and checks
+ * the state is still there. It is the test that actually justifies the choice
+ * of a stable `app://` origin over `file://`: storage is keyed by origin, so a
+ * shell whose origin changed or was opaque would come back empty.
+ *
+ * It also covers the "shutdown while work is in flight" case from the spike
+ * brief, by quitting immediately after a write rather than waiting for idle.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { launchShell, createReporter, waitForAppReady } from './harness.mjs';
+
+const MARKER = 'electron-spike-persistence-marker';
+
+export default async function run() {
+  const r = createReporter('persistence');
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'scirepl-persist-'));
+
+  try {
+    /* ---------------- first launch: write state ---------------- */
+
+    const first = await launchShell({ userDataDir });
+    let wrote;
+    try {
+      await waitForAppReady(first.page);
+
+      const originFirst = await first.page.evaluate(() => window.location.origin);
+
+      wrote = await first.page.evaluate(async (marker) => {
+        const out = {};
+
+        // 1. SharedVFS -> IndexedDB
+        const vfs = window.sharedVFS;
+        vfs.writeFile('/shared/persist.txt', marker, 'test');
+        await vfs.saveToIndexedDB();
+        out.vfsWritten = vfs.readFile('/shared/persist.txt') === marker;
+
+        // 2. A notebook, through the app's own manager.
+        try {
+          const nm = window.notebookManager;
+          if (nm && typeof nm.saveState === 'function') {
+            window._cells = window._cells || [];
+            await nm.saveState();
+            out.notebookSaved = true;
+          } else {
+            out.notebookSaved = false;
+          }
+        } catch (e) {
+          out.notebookSaved = false;
+          out.notebookError = String(e && e.message);
+        }
+
+        // 3. A direct IndexedDB write, independent of app structure, so the
+        //    result is meaningful even if the app's own APIs change.
+        out.directIdb = await new Promise((resolve) => {
+          const req = indexedDB.open('scirepl-spike-probe', 1);
+          req.onupgradeneeded = () => req.result.createObjectStore('kv');
+          req.onsuccess = () => {
+            const db = req.result;
+            const tx = db.transaction('kv', 'readwrite');
+            tx.objectStore('kv').put(marker, 'marker');
+            tx.oncomplete = () => { db.close(); resolve(true); };
+            tx.onerror = () => { db.close(); resolve(false); };
+          };
+          req.onerror = () => resolve(false);
+        });
+
+        // 4. localStorage, used for settings/preferences.
+        localStorage.setItem('scirepl_spike_marker', marker);
+        out.localStorage = localStorage.getItem('scirepl_spike_marker') === marker;
+
+        return out;
+      }, MARKER);
+
+      r.log('first launch: origin is the stable app origin', originFirst === 'app://scirepl', originFirst);
+      r.log('first launch: SharedVFS write succeeded', wrote.vfsWritten === true);
+      r.log('first launch: direct IndexedDB write succeeded', wrote.directIdb === true);
+      r.log('first launch: localStorage write succeeded', wrote.localStorage === true);
+    } finally {
+      // Quit immediately after writing — the "shutdown while work is active"
+      // case. A graceful close must still flush.
+      const { timedOut } = await first.close();
+      r.log('shell shuts down gracefully after active writes', timedOut === false,
+        timedOut ? 'close() timed out and needed SIGKILL' : '');
+    }
+
+    /* ---------------- second launch: read state back ---------------- */
+
+    const second = await launchShell({ userDataDir });
+    try {
+      await waitForAppReady(second.page);
+
+      const originSecond = await second.page.evaluate(() => window.location.origin);
+      r.log('second launch: origin is unchanged', originSecond === 'app://scirepl', originSecond);
+
+      const read = await second.page.evaluate(async (marker) => {
+        const out = {};
+
+        out.localStorage = localStorage.getItem('scirepl_spike_marker') === marker;
+
+        out.directIdb = await new Promise((resolve) => {
+          const req = indexedDB.open('scirepl-spike-probe', 1);
+          req.onupgradeneeded = () => { try { req.result.createObjectStore('kv'); } catch {} };
+          req.onsuccess = () => {
+            const db = req.result;
+            try {
+              const tx = db.transaction('kv', 'readonly');
+              const get = tx.objectStore('kv').get('marker');
+              get.onsuccess = () => { const v = get.result; db.close(); resolve(v === marker); };
+              get.onerror = () => { db.close(); resolve(false); };
+            } catch (e) { db.close(); resolve(false); }
+          };
+          req.onerror = () => resolve(false);
+        });
+
+        // SharedVFS restores itself from IndexedDB during startup.
+        try {
+          const vfs = window.sharedVFS;
+          if (typeof vfs.loadFromIndexedDB === 'function') await vfs.loadFromIndexedDB();
+          out.vfs = vfs.readFile('/shared/persist.txt') === marker;
+        } catch (e) {
+          out.vfs = false;
+          out.vfsError = String(e && e.message);
+        }
+
+        const dbs = typeof indexedDB.databases === 'function' ? await indexedDB.databases() : [];
+        out.databases = dbs.map(d => d.name).filter(Boolean).sort();
+        return out;
+      }, MARKER);
+
+      r.log('IndexedDB survives a full application restart', read.directIdb === true,
+        JSON.stringify(read.databases));
+      r.log('SharedVFS content survives a full application restart', read.vfs === true,
+        read.vfsError || '');
+      r.log('localStorage survives a full application restart', read.localStorage === true);
+    } finally {
+      await second.close();
+    }
+  } finally {
+    try { rmSync(userDataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/policy.unit.test.mjs
+++ b/desktop/electron/test/policy.unit.test.mjs
@@ -145,6 +145,21 @@ export default async function run() {
     r.log(`CSP ${why} (${needle})`, csp.includes(needle));
   }
   r.log('CSP does not allow plaintext http: origins', !/\bhttp:\/\//.test(csp));
+
+  /* ---------------- known, deliberate PWA divergence ---------------- */
+
+  // www/index.html:407 loads the Ko-fi widget from storage.ko-fi.com. It is
+  // excluded from the allowlist on purpose (a third-party script would get
+  // arbitrary execution in the realm that runs notebooks). These assertions
+  // exist so the omission stays a decision: allowing the origin, or dropping
+  // the documented exclusion, fails here and forces the choice to be re-made.
+  const kofi = protocol.KOFI_EXCLUSION;
+  r.log('the Ko-fi divergence is documented in the shell',
+    !!kofi && kofi.origin === 'https://storage.ko-fi.com', JSON.stringify(kofi));
+  r.log('storage.ko-fi.com is not in the remote allowlist',
+    !protocol.REMOTE_ORIGINS.includes('https://storage.ko-fi.com'));
+  r.log('the CSP does not permit the Ko-fi widget origin',
+    !csp.includes('ko-fi.com'));
   // Documented, deliberate relaxations — asserted so that removing them later
   // is a conscious decision rather than an accident.
   r.log("CSP allows 'unsafe-eval' (required by the JS/Scittle/Pyodide kernels)",

--- a/desktop/electron/test/policy.unit.test.mjs
+++ b/desktop/electron/test/policy.unit.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * policy.unit.test.mjs — pure unit tests for the shell's decision functions.
+ *
+ * These require neither a display nor the Electron binary, so they run on any
+ * CI runner and on any OS. They cover the parts of the policy that are easy to
+ * get subtly wrong and hard to observe from an integration test: path
+ * containment and external-URL classification.
+ *
+ * `security.js` and `protocol.js` both `require('electron')`, which resolves to
+ * a path string outside a real Electron process. Only the module *shape* is
+ * needed here, so a minimal stub is installed first.
+ */
+
+import { createRequire } from 'node:module';
+import Module from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createReporter, ELECTRON_DIR } from './reporter.mjs';
+
+/* Stub `electron` before the modules under test require it. */
+const originalResolve = Module._resolveFilename;
+const STUB = fileURLToPath(new URL('./fixtures/electron-stub.cjs', import.meta.url));
+Module._resolveFilename = function (request, ...rest) {
+  if (request === 'electron') return STUB;
+  return originalResolve.call(this, request, ...rest);
+};
+
+const require = createRequire(import.meta.url);
+const protocol = require(path.join(ELECTRON_DIR, 'protocol.js'));
+const security = require(path.join(ELECTRON_DIR, 'security.js'));
+const ipc = require(path.join(ELECTRON_DIR, 'ipc.js'));
+
+export default async function run() {
+  const r = createReporter('policy-unit');
+  const ROOT = path.resolve('/srv/app/www');
+
+  /* ---------------- path containment ---------------- */
+
+  const contained = [
+    ['/index.html', 'index.html'],
+    ['/', 'index.html'],
+    ['/js/app.js', path.join('js', 'app.js')],
+    ['/vendor/pyodide/pyodide.asm.wasm', path.join('vendor', 'pyodide', 'pyodide.asm.wasm')],
+    ['/js/../js/app.js', path.join('js', 'app.js')],
+    // A filename that merely *starts* with the root's basename must not be
+    // confused for the root itself — the classic prefix-comparison bug.
+    ['/wwwroot-notes.txt', 'wwwroot-notes.txt'],
+  ];
+  for (const [input, expectedRel] of contained) {
+    const got = protocol.resolveRequestPath(ROOT, input);
+    const want = path.join(ROOT, expectedRel);
+    r.log(`serves contained path ${input}`, got === want, `${got}`);
+  }
+
+  const rejected = [
+    '/../package.json',
+    '/../../etc/passwd',
+    '/js/../../package.json',
+    '/%2e%2e/package.json',            // decoded by the handler into ..
+    '/..%2f..%2fpackage.json',
+    '/js/%2e%2e%2f%2e%2e%2fpackage.json',
+    '/\0/etc/passwd',
+    '/%00etc/passwd',
+    '/%ZZ',                            // malformed percent-encoding
+  ];
+  for (const input of rejected) {
+    const got = protocol.resolveRequestPath(ROOT, input);
+    const escapesRoot = got !== null && !got.startsWith(ROOT + path.sep);
+    r.log(`refuses to escape www/ for ${JSON.stringify(input)}`,
+      got === null || !escapesRoot, String(got));
+  }
+
+  // Explicit: the traversal cases must not merely stay inside the root by
+  // accident, they must be refused outright.
+  const hardRejects = ['/../package.json', '/%2e%2e/package.json', '/%00etc/passwd', '/%ZZ'];
+  for (const input of hardRejects) {
+    r.log(`returns null for ${JSON.stringify(input)}`,
+      protocol.resolveRequestPath(ROOT, input) === null);
+  }
+
+  /* ---------------- external URL classification ---------------- */
+
+  const allowedExternal = [
+    'https://github.com/s243a/SciREPL#readme',
+    'https://repo.r-wasm.org/',
+    'mailto:someone@example.com',
+  ];
+  for (const url of allowedExternal) {
+    r.log(`allows external ${url}`, security.isAllowedExternal(url) === true);
+  }
+
+  const deniedExternal = [
+    'file:///etc/passwd',                  // local file disclosure
+    'file://C:/Windows/System32/cmd.exe',
+    'http://example.com/',                 // plaintext
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'ms-settings:privacy',                 // Windows protocol handler
+    'shell:startup',
+    'app://scirepl/index.html',            // internal, not an external open
+    'https://user:pass@example.com/',      // credentials in URL
+    'not a url',
+    '',
+  ];
+  for (const url of deniedExternal) {
+    r.log(`denies external ${JSON.stringify(url)}`, security.isAllowedExternal(url) === false);
+  }
+
+  /* ---------------- app-origin classification ---------------- */
+
+  r.log('recognises the app origin', security.isAppUrl('app://scirepl/index.html') === true);
+  r.log('reload URL is in-app', security.isAppUrl('app://scirepl/') === true);
+  r.log('a different app:// host is not in-app', security.isAppUrl('app://evil/index.html') === false);
+  r.log('https is not in-app', security.isAppUrl('https://scirepl/') === false);
+  r.log('an app-origin lookalike host is not in-app',
+    security.isAppUrl('app://scirepl.evil.com/x') === false);
+
+  /* ---------------- IPC allowlist ---------------- */
+
+  const channels = ipc.listRegisteredChannels();
+  r.log('IPC allowlist is exactly the two read-only operations',
+    JSON.stringify([...channels].sort()) ===
+      JSON.stringify(['scirepl:get-app-info', 'scirepl:get-distribution-info']),
+    JSON.stringify(channels));
+
+  let threw = false;
+  try { ipc.assertNullary('test', ['x']); } catch { threw = true; }
+  r.log('assertNullary rejects arguments', threw === true);
+
+  let threwEmpty = false;
+  try { ipc.assertNullary('test', []); } catch { threwEmpty = true; }
+  r.log('assertNullary accepts no arguments', threwEmpty === false);
+
+  /* ---------------- CSP shape ---------------- */
+
+  const csp = protocol.buildCsp();
+  const cspChecks = [
+    ["object-src 'none'", "blocks plugins"],
+    ["frame-ancestors 'none'", "cannot be framed"],
+    ["form-action 'none'", "cannot post forms"],
+    ["base-uri 'self'", "cannot rewrite the base URI"],
+  ];
+  for (const [needle, why] of cspChecks) {
+    r.log(`CSP ${why} (${needle})`, csp.includes(needle));
+  }
+  r.log('CSP does not allow plaintext http: origins', !/\bhttp:\/\//.test(csp));
+  // Documented, deliberate relaxations — asserted so that removing them later
+  // is a conscious decision rather than an accident.
+  r.log("CSP allows 'unsafe-eval' (required by the JS/Scittle/Pyodide kernels)",
+    csp.includes("'unsafe-eval'"));
+  r.log("CSP allows 'wasm-unsafe-eval' (required by every WASM kernel)",
+    csp.includes("'wasm-unsafe-eval'"));
+
+  Module._resolveFilename = originalResolve;
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/probes/kernels.mjs
+++ b/desktop/electron/test/probes/kernels.mjs
@@ -1,0 +1,195 @@
+/**
+ * probes/kernels.mjs — one representative execution per kernel, plus the
+ * cross-kernel SharedVFS path.
+ *
+ * These probes take a Playwright `Page` and nothing else. The Electron runner
+ * and the browser-baseline runner both drive this same module, so any
+ * difference in the results is a real difference between the packaged origin
+ * and the browser, not a difference between two test suites.
+ *
+ * The probes deliberately reuse the application's own entry points
+ * (`window.kernelManager.ensureReady` / `.execute`, `window.sharedVFS`) — the
+ * same ones the existing browser tests in the repository root use — rather than
+ * reaching into kernel internals.
+ */
+
+/** Kernels and a minimal program whose output is unambiguous. */
+export const KERNEL_CASES = [
+  {
+    lang: 'javascript',
+    label: 'JavaScript (native)',
+    code: 'console.log(6 * 7)',
+    expect: /42/,
+    network: false,
+  },
+  {
+    lang: 'bash',
+    label: 'Bash / Brush (WASM, bundled)',
+    code: 'echo $((6 * 7))',
+    expect: /42/,
+    network: false,
+  },
+  {
+    lang: 'typr',
+    label: 'TypR (WASM, bundled + webR)',
+    code: 'let x <- 42\ncat(x)',
+    expect: /42/,
+    network: true, // TypR's init calls ensureReady('r'), which fetches webR
+    // Measured in this spike: the kernel initialises and executes without
+    // error, but `cat()` output does not reach `execute()`'s stdout, so the
+    // output assertion fails. The browser baseline fails identically, and the
+    // repository's own test_typr_kernel.mjs already tolerates empty output
+    // here — so this is a pre-existing application gap, not something the
+    // Electron origin introduced. Tracked as such rather than silently
+    // relaxed; the parity check below still fails if Electron ever diverges.
+    knownIssue: 'cat() output is not surfaced through execute() stdout; reproduces identically in the browser baseline',
+  },
+  {
+    lang: 'lua',
+    label: 'Lua / Fengari (CDN)',
+    code: 'print(6 * 7)',
+    expect: /42/,
+    network: true,
+  },
+  {
+    lang: 'clojurescript',
+    label: 'ClojureScript / Scittle (bundled)',
+    code: '(println (* 6 7))',
+    expect: /42/,
+    network: false,
+  },
+  {
+    lang: 'prolog',
+    label: 'SWI-Prolog (WASM, bundled)',
+    code: 'X is 6 * 7, format("~w~n", [X]).',
+    expect: /42/,
+    network: false,
+  },
+  {
+    lang: 'python',
+    label: 'Python / Pyodide (WASM, bundled)',
+    code: 'print(6 * 7)',
+    expect: /42/,
+    network: false,
+  },
+  {
+    lang: 'r',
+    label: 'R / webR (WASM, CDN in the Free profile)',
+    code: 'cat(6 * 7)',
+    expect: /42/,
+    network: true,
+  },
+];
+
+/** Which kernels the running build actually enables, per kernel_config.js. */
+export async function enabledKernels(page) {
+  return page.evaluate(() => {
+    const cfg = window.KERNEL_CONFIG || { languages: {} };
+    return Object.entries(cfg.languages || {})
+      .filter(([, v]) => v && v.enabled)
+      .map(([k]) => k);
+  });
+}
+
+export async function registeredKernels(page) {
+  return page.evaluate(() => Object.keys((window.kernelManager && window.kernelManager._registry) || {}));
+}
+
+/**
+ * Initialise and run one kernel. Returns a structured result rather than
+ * throwing, so one broken kernel does not hide the rest of the matrix.
+ */
+export async function runKernel(page, { lang, code }, timeoutMs = 240_000) {
+  return page.evaluate(async ({ lang, code, timeoutMs }) => {
+    const started = performance.now();
+    const withTimeout = (p, ms, what) => Promise.race([
+      p,
+      new Promise((_, rej) => setTimeout(() => rej(new Error(`${what} timed out after ${ms}ms`)), ms)),
+    ]);
+
+    try {
+      const km = window.kernelManager;
+      if (!km || !km._registry || !km._registry[lang]) {
+        return { status: 'unregistered', lang };
+      }
+
+      await withTimeout(km.ensureReady(lang), timeoutMs, `${lang} init`);
+      const readyAt = performance.now();
+
+      const res = await withTimeout(km.execute(code, lang), timeoutMs, `${lang} execute`);
+      const doneAt = performance.now();
+
+      const text = [
+        res && res.stdout ? res.stdout : '',
+        res && res.result && res.result.content ? res.result.content : '',
+      ].join('\n').trim();
+
+      return {
+        status: res && res.error ? 'error' : 'ok',
+        lang,
+        output: text,
+        error: res && res.error ? String(res.error) : null,
+        initMs: Math.round(readyAt - started),
+        execMs: Math.round(doneAt - readyAt),
+      };
+    } catch (e) {
+      return { status: 'threw', lang, error: String((e && e.message) || e), initMs: null, execMs: null };
+    }
+  }, { lang, code, timeoutMs });
+}
+
+/**
+ * Cross-kernel SharedVFS: write from one kernel's side, read from another.
+ * This is the path that would break first if workers or storage misbehaved
+ * under a custom origin.
+ */
+export async function probeSharedVfs(page) {
+  return page.evaluate(async () => {
+    const out = {};
+    try {
+      const vfs = window.sharedVFS;
+      if (!vfs) return { available: false };
+      out.available = true;
+
+      const marker = 'electron-spike-' + Date.now();
+      vfs.writeFile('/shared/spike.txt', marker, 'test');
+      out.roundTrip = vfs.readFile('/shared/spike.txt') === marker;
+      out.exists = vfs.exists('/shared/spike.txt') === true;
+
+      // Visible to a kernel? Python mounts /shared through sharedfs.py.
+      try {
+        const km = window.kernelManager;
+        await km.ensureReady('python');
+        const res = await km.execute(
+          "open('/shared/spike.txt').read()", 'python');
+        const seen = ((res.stdout || '') + (res.result?.content || ''));
+        out.visibleToPython = seen.includes(marker);
+        out.pythonError = res.error || null;
+      } catch (e) {
+        out.visibleToPython = false;
+        out.pythonError = String(e && e.message);
+      }
+
+      // Persist to IndexedDB — the operation the restart test depends on.
+      if (typeof vfs.saveToIndexedDB === 'function') {
+        await vfs.saveToIndexedDB();
+        out.savedToIndexedDb = true;
+      }
+      out.marker = marker;
+      return out;
+    } catch (e) {
+      return { available: false, error: String(e && e.message) };
+    }
+  });
+}
+
+/** Enumerate IndexedDB databases the application created. */
+export async function probeIndexedDb(page) {
+  return page.evaluate(async () => {
+    if (!indexedDB || typeof indexedDB.databases !== 'function') {
+      return { supported: !!indexedDB, enumerable: false };
+    }
+    const dbs = await indexedDB.databases();
+    return { supported: true, enumerable: true, names: dbs.map(d => d.name).filter(Boolean).sort() };
+  });
+}

--- a/desktop/electron/test/reporter.mjs
+++ b/desktop/electron/test/reporter.mjs
@@ -1,0 +1,45 @@
+/**
+ * reporter.mjs — assertion/reporting helpers and repository paths.
+ *
+ * Deliberately free of any dependency, including Playwright. `policy.unit.test.mjs`
+ * imports from here rather than from harness.mjs so the unit suite can run with
+ * only `desktop/electron`'s own dependencies installed — that is what the
+ * `shell-policy` CI job does, and it is why that job needs neither a display
+ * nor the ~220 MB Electron download.
+ */
+
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export const ELECTRON_DIR = fileURLToPath(new URL('..', import.meta.url));
+export const REPO_ROOT = path.resolve(ELECTRON_DIR, '..', '..');
+export const WWW_ROOT = path.join(REPO_ROOT, 'www');
+
+/** The origin the shell serves the application from. Mirrors protocol.js. */
+export const APP_ORIGIN = 'app://scirepl';
+
+/** Matches the reporting style of the repository's existing browser tests. */
+export function createReporter(suiteName) {
+  const results = [];
+  let failed = 0;
+  return {
+    log(name, passed, detail = '') {
+      if (!passed) failed++;
+      results.push({ name, passed, detail });
+      const mark = passed ? 'PASS' : 'FAIL';
+      console.log(`  [${mark}] ${name}${detail ? ': ' + String(detail).trim().slice(0, 400) : ''}`);
+    },
+    /** Record a check that could not be executed here. Never counted as a pass. */
+    skip(name, reason) {
+      results.push({ name, passed: null, detail: reason });
+      console.log(`  [SKIP] ${name}: ${reason}`);
+    },
+    summary() {
+      const passed = results.filter(r => r.passed === true).length;
+      const skipped = results.filter(r => r.passed === null).length;
+      console.log(`\n${suiteName}: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+      return { suiteName, results, failed, passed, skipped };
+    },
+    get failed() { return failed; },
+  };
+}

--- a/desktop/electron/test/reporter.mjs
+++ b/desktop/electron/test/reporter.mjs
@@ -11,7 +11,11 @@
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-export const ELECTRON_DIR = fileURLToPath(new URL('..', import.meta.url));
+// path.resolve() strips the trailing separator that fileURLToPath leaves on a
+// directory URL. That matters: this path is passed to Electron as the app
+// directory argument, and a Windows path ending in a backslash ("D:\...\electron\")
+// is a hazard for command-line quoting.
+export const ELECTRON_DIR = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 export const REPO_ROOT = path.resolve(ELECTRON_DIR, '..', '..');
 export const WWW_ROOT = path.join(REPO_ROOT, 'www');
 

--- a/desktop/electron/test/run-all.mjs
+++ b/desktop/electron/test/run-all.mjs
@@ -46,8 +46,24 @@ if (selected.length === 0) {
 const summaries = [];
 let totalFailed = 0;
 
+/**
+ * If the shell cannot be launched at all, every Electron-dependent suite will
+ * fail the same way after its own 120s launch timeout. That is ~12 minutes of
+ * identical output that buries the one message worth reading, so the first
+ * launch failure stops the rest from being attempted.
+ */
+let launchFailure = null;
+const isLaunchFailure = (err) => String(err && err.message).includes('Failed to launch the Electron shell');
+
 for (const suite of selected) {
   console.log(`\n=== ${suite.name} ===`);
+
+  if (launchFailure && !suite.unit) {
+    console.log('  [SKIP] not attempted — the shell failed to launch in an earlier suite.');
+    summaries.push({ suiteName: suite.name, failed: 0, passed: 0, skipped: 1, notAttempted: true });
+    continue;
+  }
+
   try {
     const mod = await import(suite.file);
     const summary = await mod.default();
@@ -57,6 +73,15 @@ for (const suite of selected) {
     console.log(`  [FAIL] suite crashed: ${err && err.stack ? err.stack : err}`);
     summaries.push({ suiteName: suite.name, failed: 1, passed: 0, skipped: 0, crashed: String(err) });
     totalFailed += 1;
+    if (isLaunchFailure(err)) {
+      launchFailure = err;
+      console.log(
+        '\n  The Electron shell could not be launched. Remaining shell suites will be\n' +
+        '  skipped rather than repeating this failure. Run the diagnostic for the\n' +
+        "  main process's own output:\n" +
+        '    node desktop/electron/test/smoke.mjs'
+      );
+    }
   }
 }
 

--- a/desktop/electron/test/run-all.mjs
+++ b/desktop/electron/test/run-all.mjs
@@ -1,0 +1,75 @@
+/**
+ * run-all.mjs — run the Electron shell's test suites.
+ *
+ *   node desktop/electron/test/run-all.mjs            # everything
+ *   node desktop/electron/test/run-all.mjs --unit     # no Electron binary, no display
+ *   node desktop/electron/test/run-all.mjs security persistence
+ *
+ * `--unit` selects only the suites that are pure Node, which is what a
+ * cross-platform CI job can run without a display or a downloaded Electron
+ * build. Everything else needs a real shell.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RESULTS_DIR = fileURLToPath(new URL('./results', import.meta.url));
+
+/** `unit: true` means it needs neither a display nor the Electron binary. */
+const SUITES = [
+  { name: 'policy-unit', file: './policy.unit.test.mjs', unit: true },
+  { name: 'shell-launch', file: './shell-launch.test.mjs', unit: false },
+  { name: 'security', file: './security.test.mjs', unit: false },
+  { name: 'artifact-boundary', file: './artifact-boundary.test.mjs', unit: false },
+  { name: 'download', file: './download.test.mjs', unit: false },
+  { name: 'persistence', file: './persistence.test.mjs', unit: false },
+  { name: 'kernels', file: './kernels.test.mjs', unit: false },
+  { name: 'offline', file: './offline.test.mjs', unit: false },
+];
+
+const argv = process.argv.slice(2);
+const unitOnly = argv.includes('--unit');
+const named = argv.filter(a => !a.startsWith('--'));
+
+const selected = SUITES.filter(s => {
+  if (named.length) return named.includes(s.name);
+  if (unitOnly) return s.unit;
+  return true;
+});
+
+if (selected.length === 0) {
+  console.error(`No suites matched. Available: ${SUITES.map(s => s.name).join(', ')}`);
+  process.exit(2);
+}
+
+const summaries = [];
+let totalFailed = 0;
+
+for (const suite of selected) {
+  console.log(`\n=== ${suite.name} ===`);
+  try {
+    const mod = await import(suite.file);
+    const summary = await mod.default();
+    summaries.push(summary);
+    totalFailed += summary.failed;
+  } catch (err) {
+    console.log(`  [FAIL] suite crashed: ${err && err.stack ? err.stack : err}`);
+    summaries.push({ suiteName: suite.name, failed: 1, passed: 0, skipped: 0, crashed: String(err) });
+    totalFailed += 1;
+  }
+}
+
+console.log('\n================ summary ================');
+for (const s of summaries) {
+  console.log(`  ${String(s.suiteName).padEnd(20)} ${s.passed} passed, ${s.failed} failed, ${s.skipped || 0} skipped`);
+}
+console.log(`  ${'TOTAL'.padEnd(20)} ${totalFailed} failed`);
+
+mkdirSync(RESULTS_DIR, { recursive: true });
+writeFileSync(
+  path.join(RESULTS_DIR, 'summary.json'),
+  JSON.stringify({ generatedAt: new Date().toISOString(), platform: process.platform, summaries }, null, 2)
+);
+
+process.exit(totalFailed > 0 ? 1 : 0);

--- a/desktop/electron/test/security.test.mjs
+++ b/desktop/electron/test/security.test.mjs
@@ -1,0 +1,209 @@
+/**
+ * security.test.mjs — regression tests for the renderer/native boundary.
+ *
+ * These are written from the notebook author's position: everything here is
+ * executed the way a hostile notebook cell would execute it, i.e. in the main
+ * world of the renderer, via the JavaScript kernel where possible. The point is
+ * not that SciREPL's own code behaves — it is that *arbitrary user code* cannot
+ * reach Node or unrestricted Electron capability.
+ */
+
+import { launchShell, createReporter, waitForAppReady, attachLogs } from './harness.mjs';
+
+/** Run a snippet through the real JavaScript kernel, as a notebook cell would. */
+async function runNotebookCell(page, code) {
+  return page.evaluate(async (src) => {
+    const km = window.kernelManager;
+    await km.ensureReady('javascript');
+    return await km.execute(src, 'javascript');
+  }, code);
+}
+
+export default async function run() {
+  const r = createReporter('security');
+  const shell = await launchShell();
+  attachLogs(shell.page);
+
+  try {
+    const { page } = shell;
+    await waitForAppReady(page);
+
+    // Record whether the OS sandbox was actually on, so a relaxed CI run can
+    // never be mistaken for a clean one in the report.
+    const sandboxRelaxed = process.env.SCIREPL_ELECTRON_NO_SANDBOX === '1';
+    r.log('renderer ran with the OS sandbox enabled', !sandboxRelaxed,
+      sandboxRelaxed ? 'SCIREPL_ELECTRON_NO_SANDBOX=1 — result does not attest to OS sandboxing' : '');
+
+    /* ---------------- Node is absent from the renderer ---------------- */
+
+    const nodeGlobals = await page.evaluate(() => ({
+      require: typeof window.require,
+      process: typeof window.process,
+      Buffer: typeof window.Buffer,
+      module: typeof window.module,
+      exports: typeof window.exports,
+      global: typeof window.global,
+      __dirname: typeof window.__dirname,
+      electron: typeof window.electron,
+      ipcRenderer: typeof window.ipcRenderer,
+    }));
+    for (const [name, type] of Object.entries(nodeGlobals)) {
+      r.log(`renderer global \`${name}\` is undefined`, type === 'undefined', type);
+    }
+
+    /* ------- the same, but executed as a notebook cell (the real threat) ------- */
+
+    const cellProbe = await runNotebookCell(page, `
+      const probe = {};
+      for (const name of ['require','process','Buffer','module','__dirname','global','electron','ipcRenderer']) {
+        try { probe[name] = typeof eval(name); } catch (e) { probe[name] = 'ReferenceError'; }
+      }
+      JSON.stringify(probe)
+    `);
+    let cellGlobals = {};
+    try { cellGlobals = JSON.parse(cellProbe.result?.content || '{}'); } catch { /* leave empty */ }
+    const reachable = Object.entries(cellGlobals).filter(([, v]) => v !== 'undefined' && v !== 'ReferenceError');
+    r.log('notebook cell cannot reach any Node global',
+      reachable.length === 0, JSON.stringify(cellGlobals));
+
+    // The classic escapes.
+    const escapes = await runNotebookCell(page, `
+      const out = {};
+      try { out.processViaCtor = typeof (new Function('return process'))(); } catch (e) { out.processViaCtor = 'blocked:' + e.name; }
+      try { out.requireViaTop = typeof top.require; } catch (e) { out.requireViaTop = 'blocked:' + e.name; }
+      try { out.requireViaParent = typeof parent.require; } catch (e) { out.requireViaParent = 'blocked:' + e.name; }
+      JSON.stringify(out)
+    `);
+    let escapeResult = {};
+    try { escapeResult = JSON.parse(escapes.result?.content || '{}'); } catch { /* leave empty */ }
+    const escaped = Object.entries(escapeResult).filter(([, v]) => v === 'function' || v === 'object');
+    r.log('notebook cell cannot reach Node via Function constructor / top / parent',
+      escaped.length === 0, JSON.stringify(escapeResult));
+
+    /* ---------------- the exposed surface is exactly the allowlist ---------------- */
+
+    const surface = await page.evaluate(() => {
+      const api = window.sciREPLPlatform;
+      if (!api) return null;
+      return {
+        keys: Object.keys(api).sort(),
+        frozen: Object.isFrozen(api),
+        types: Object.fromEntries(Object.keys(api).map(k => [k, typeof api[k]])),
+      };
+    });
+    r.log('preload exposes the platform API', surface !== null, JSON.stringify(surface));
+    r.log('exposed surface is exactly [getAppInfo, getDistributionInfo]',
+      surface && JSON.stringify(surface.keys) === JSON.stringify(['getAppInfo', 'getDistributionInfo']),
+      surface && JSON.stringify(surface.keys));
+    r.log('exposed API object is frozen', surface?.frozen === true);
+
+    // No generic escape hatch of any name.
+    const hatches = await page.evaluate(() => {
+      const api = window.sciREPLPlatform || {};
+      return ['invoke', 'send', 'on', 'ipc', 'ipcRenderer', 'require', 'exec', 'spawn',
+        'readFile', 'writeFile', 'fs', 'shell', 'openPath', 'eval']
+        .filter(k => typeof api[k] !== 'undefined');
+    });
+    r.log('no generic invoke/send/fs/shell escape hatch is exposed',
+      Array.isArray(hatches) && hatches.length === 0, JSON.stringify(hatches));
+
+    /* ---------------- the allowlisted ops are safe and work ---------------- */
+
+    const appInfo = await page.evaluate(() => window.sciREPLPlatform.getAppInfo());
+    r.log('getAppInfo returns build facts only',
+      !!appInfo && typeof appInfo.electronVersion === 'string' && !('cwd' in appInfo) && !('env' in appInfo),
+      JSON.stringify(appInfo));
+
+    const dist = await page.evaluate(() => window.sciREPLPlatform.getDistributionInfo());
+    r.log('getDistributionInfo reports the Free edition',
+      dist && dist.edition === 'free' && dist.container === 'electron', JSON.stringify(dist));
+    r.log('no entitlement/licence value is fabricated',
+      dist && dist.store === null, JSON.stringify(dist && dist.store));
+
+    // Renderer-supplied arguments are inert: the preload wrapper takes no
+    // parameters and forwards none, so nothing the caller passes can reach the
+    // main process or influence the reply. (The main process independently
+    // rejects arguments on the channel — see ipc.unit.test.mjs, which covers
+    // assertNullary directly; that guard matters if the channel is ever reached
+    // by something other than this wrapper.)
+    const argEffect = await page.evaluate(async () => {
+      const plain = await window.sciREPLPlatform.getAppInfo();
+      const withArgs = await window.sciREPLPlatform.getAppInfo('extra', { evil: true }, 42);
+      return { same: JSON.stringify(plain) === JSON.stringify(withArgs), withArgs };
+    });
+    r.log('renderer-supplied arguments to the platform API are inert',
+      argEffect.same === true, JSON.stringify(argEffect.withArgs));
+
+    /* ---------------- navigation policy ---------------- */
+
+    // A notebook cell trying to navigate the shell to a remote origin.
+    const beforeUrl = page.url();
+    await runNotebookCell(page, `try { window.location.href = 'https://example.com/'; } catch (e) {} ; 1`);
+    await page.waitForTimeout(1500);
+    const afterUrl = page.url();
+    r.log('notebook cell cannot navigate the window off the app origin',
+      afterUrl === beforeUrl, `${beforeUrl} -> ${afterUrl}`);
+
+    // The mirror image, and a regression guard: navigation *within* the app
+    // must still work. The will-navigate policy classifies URLs in the main
+    // process, where Node reports `origin === 'null'` for the custom scheme;
+    // an origin-based check silently blocked all in-app navigation here.
+    await page.evaluate(() => { window.location.href = 'privacy.html'; });
+    await page.waitForURL(/privacy\.html$/, { timeout: 30_000 }).catch(() => {});
+    const navigatedInApp = page.url();
+    r.log('in-app navigation is permitted', /privacy\.html$/.test(navigatedInApp), navigatedInApp);
+
+    await page.goto('app://scirepl/index.html', { waitUntil: 'domcontentloaded', timeout: 120_000 });
+    await waitForAppReady(page);
+    r.log('can navigate back to the application root', /index\.html$/.test(page.url()), page.url());
+
+    // window.open must never produce a second renderer.
+    const windowCount = await shell.electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+    await runNotebookCell(page, `try { window.open('https://example.com/'); } catch (e) {}; 1`);
+    await page.waitForTimeout(1500);
+    const windowCountAfter = await shell.electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+    r.log('window.open does not create a new Electron window',
+      windowCountAfter === windowCount, `${windowCount} -> ${windowCountAfter}`);
+
+    /* ---------------- webPreferences are as declared ---------------- */
+
+    const prefs = await shell.electronApp.evaluate(({ BrowserWindow }) => {
+      const w = BrowserWindow.getAllWindows()[0];
+      const wc = w.webContents;
+      return {
+        // These are the values the main process actually constructed the window with.
+        nodeIntegration: wc.getLastWebPreferences()?.nodeIntegration ?? null,
+        contextIsolation: wc.getLastWebPreferences()?.contextIsolation ?? null,
+        sandbox: wc.getLastWebPreferences()?.sandbox ?? null,
+        webSecurity: wc.getLastWebPreferences()?.webSecurity ?? null,
+        webviewTag: wc.getLastWebPreferences()?.webviewTag ?? null,
+      };
+    });
+    r.log('nodeIntegration is false', prefs.nodeIntegration === false, String(prefs.nodeIntegration));
+    r.log('contextIsolation is true', prefs.contextIsolation === true, String(prefs.contextIsolation));
+    r.log('sandbox is true', prefs.sandbox === true, String(prefs.sandbox));
+    r.log('webSecurity is enabled', prefs.webSecurity !== false, String(prefs.webSecurity));
+    r.log('webviewTag is disabled', prefs.webviewTag === false, String(prefs.webviewTag));
+
+    /* ---------------- no remote module ---------------- */
+
+    const remote = await shell.electronApp.evaluate(async ({ app }) => {
+      let hasRemote = false;
+      try {
+        // @electron/remote is not a dependency; if it were reachable this throws not.
+        require('@electron/remote/main');
+        hasRemote = true;
+      } catch { hasRemote = false; }
+      return { hasRemote, packaged: app.isPackaged };
+    });
+    r.log('the remote module is not enabled', remote.hasRemote === false);
+  } finally {
+    await shell.close();
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/security.test.mjs
+++ b/desktop/electron/test/security.test.mjs
@@ -22,7 +22,7 @@ async function runNotebookCell(page, code) {
 export default async function run() {
   const r = createReporter('security');
   const shell = await launchShell();
-  attachLogs(shell.page);
+  const attachedLogs = attachLogs(shell.page);
 
   try {
     const { page } = shell;
@@ -184,6 +184,43 @@ export default async function run() {
     r.log('sandbox is true', prefs.sandbox === true, String(prefs.sandbox));
     r.log('webSecurity is enabled', prefs.webSecurity !== false, String(prefs.webSecurity));
     r.log('webviewTag is disabled', prefs.webviewTag === false, String(prefs.webviewTag));
+
+    /* ---------------- known, deliberate PWA divergence: Ko-fi widget ---------------- */
+
+    // www/index.html:407 loads the Ko-fi support widget from storage.ko-fi.com,
+    // which is not on the CSP allowlist (see KOFI_EXCLUSION in protocol.js).
+    // This asserts the divergence is real, contained, and silent — and captures
+    // the actual CSP violation so the check cannot pass vacuously on a machine
+    // that simply has no network.
+    await page.addInitScript(() => {
+      window.__cspViolations = [];
+      document.addEventListener('securitypolicyviolation', (e) => {
+        window.__cspViolations.push({ uri: e.blockedURI, directive: e.effectiveDirective });
+      });
+    });
+    await page.reload({ waitUntil: 'load', timeout: 120_000 });
+    await waitForAppReady(page);
+    await page.waitForTimeout(1500); // let the blocked <script> resolve
+
+    const kofi = await page.evaluate(() => ({
+      widgetGlobal: typeof window.kofiwidget2,
+      violations: window.__cspViolations || [],
+      // Proof that only the widget was lost: the rest of the Help panel is intact.
+      helpPrivacyLink: !!document.getElementById('help-privacy-link'),
+      helpPanel: !!document.getElementById('help-modal') || !!document.querySelector('#help-privacy-link'),
+    }));
+
+    const kofiBlockedByCsp = kofi.violations.some(v => String(v.uri).includes('ko-fi.com'));
+    r.log('the Ko-fi widget origin is blocked by CSP, not merely unreachable',
+      kofiBlockedByCsp, JSON.stringify(kofi.violations));
+    r.log('the Ko-fi widget does not load in the shell (known divergence)',
+      kofi.widgetGlobal === 'undefined', kofi.widgetGlobal);
+    r.log('blocking the widget degrades silently — the rest of Help is intact',
+      kofi.helpPrivacyLink === true, JSON.stringify(kofi));
+
+    const kofiErrors = attachedLogs.filter(l => l.startsWith('[pageerror]') && /ko-?fi/i.test(l));
+    r.log('blocking the widget raises no uncaught page error',
+      kofiErrors.length === 0, kofiErrors.join(' | '));
 
     /* ---------------- no remote module ---------------- */
 

--- a/desktop/electron/test/shell-launch.test.mjs
+++ b/desktop/electron/test/shell-launch.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * shell-launch.test.mjs — the shell starts, serves the app from the intended
+ * origin, and the origin actually behaves like a real secure origin.
+ *
+ * This is the test that answers the spike's first question: does SciREPL load
+ * at all under a custom application protocol, without a public server?
+ */
+
+import { launchShell, createReporter, waitForAppReady, attachLogs, APP_ORIGIN } from './harness.mjs';
+
+export default async function run() {
+  const r = createReporter('shell-launch');
+  const shell = await launchShell();
+  const logs = attachLogs(shell.page);
+
+  try {
+    const { page } = shell;
+
+    // --- origin model ---
+    const url = page.url();
+    r.log('window loads from the app:// origin', url.startsWith(`${APP_ORIGIN}/`), url);
+
+    const origin = await page.evaluate(() => window.location.origin);
+    r.log('document origin is the stable app origin', origin === APP_ORIGIN, origin);
+
+    const secure = await page.evaluate(() => window.isSecureContext);
+    r.log('origin is a Secure Context', secure === true, `isSecureContext=${secure}`);
+
+    // A non-opaque origin is the precondition for IndexedDB surviving restart.
+    const opaque = await page.evaluate(() => window.origin === 'null');
+    r.log('origin is not opaque', opaque === false);
+
+    // --- the application itself booted ---
+    await waitForAppReady(page);
+    r.log('window.kernelManager is present', true);
+
+    const title = await page.title();
+    r.log('document title loaded', /sci\s*repl/i.test(title), title);
+
+    // Relative asset resolution under a custom scheme is the thing most likely
+    // to silently break; assert a real vendored asset resolved and executed.
+    const vendored = await page.evaluate(() => ({
+      katex: typeof window.katex,
+      marked: typeof window.marked,
+      plotly: typeof window.Plotly,
+      jszip: typeof window.JSZip,
+      hljs: typeof window.hljs,
+    }));
+    for (const [name, type] of Object.entries(vendored)) {
+      r.log(`relative vendored asset executed: ${name}`, type !== 'undefined', type);
+    }
+
+    // --- fetch() of app:// URLs, used by kernel loading ---
+    const fetched = await page.evaluate(async () => {
+      const res = await fetch('js/kernel_config.js');
+      return { ok: res.ok, status: res.status, type: res.headers.get('content-type') };
+    });
+    r.log('fetch() of a relative app:// asset works', fetched.ok === true, JSON.stringify(fetched));
+
+    // --- correct MIME for WebAssembly streaming ---
+    const wasmType = await page.evaluate(async () => {
+      const res = await fetch('vendor/brush/brush_wasm_bg.wasm');
+      return { ok: res.ok, type: res.headers.get('content-type') };
+    });
+    r.log('.wasm is served as application/wasm',
+      wasmType.type === 'application/wasm', JSON.stringify(wasmType));
+
+    // Prove streaming compilation actually works, not just the header.
+    const streaming = await page.evaluate(async () => {
+      try {
+        const mod = await WebAssembly.compileStreaming(fetch('vendor/brush/brush_wasm_bg.wasm'));
+        return { ok: !!mod };
+      } catch (e) {
+        return { ok: false, error: String(e && e.message) };
+      }
+    });
+    r.log('WebAssembly.compileStreaming succeeds under app://',
+      streaming.ok === true, streaming.error || '');
+
+    // --- path containment ---
+    // Plain `../` is normalised away by the URL parser before it reaches the
+    // handler, so the case that actually exercises resolveRequestPath is the
+    // percent-encoded one, which survives parsing and is decoded by us.
+    const escaped = await page.evaluate(async () => {
+      const out = {};
+      for (const p of ['/../../package.json', '/%2e%2e/%2e%2e/package.json', '/..%2f..%2fpackage.json']) {
+        try {
+          const res = await fetch(p);
+          out[p] = res.status;
+        } catch (e) {
+          out[p] = 'threw';
+        }
+      }
+      return out;
+    });
+    const noneServed = Object.values(escaped).every(v => v !== 200);
+    r.log('traversal outside www/ is refused (raw and percent-encoded)',
+      noneServed, JSON.stringify(escaped));
+
+    // --- CSP is actually attached to the document ---
+    const cspApplied = await page.evaluate(async () => {
+      const res = await fetch('index.html');
+      return res.headers.get('content-security-policy') || '';
+    });
+    r.log('document carries a Content-Security-Policy',
+      cspApplied.includes("frame-ancestors 'none'") && cspApplied.includes("object-src 'none'"),
+      cspApplied.slice(0, 120));
+
+    // --- reload ---
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+    await waitForAppReady(page);
+    const originAfter = await page.evaluate(() => window.location.origin);
+    r.log('application survives reload with the same origin', originAfter === APP_ORIGIN, originAfter);
+
+    const fatal = logs.filter(l => l.startsWith('[pageerror]'));
+    r.log('no uncaught page errors during startup', fatal.length === 0, fatal.slice(0, 3).join(' | '));
+  } finally {
+    await shell.close();
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then(s => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/smoke.mjs
+++ b/desktop/electron/test/smoke.mjs
@@ -1,0 +1,121 @@
+/**
+ * smoke.mjs — launch the shell directly and report exactly what happened.
+ *
+ * Playwright reports a failed Electron launch as `Timeout 120000ms exceeded`
+ * with none of the main process's own output, which is close to undiagnosable
+ * on a CI machine you cannot log into. This script bypasses Playwright: it
+ * spawns the Electron binary itself, captures raw stdout/stderr, and prints
+ * them.
+ *
+ * If the default launch fails it retries once with the flags that most often
+ * unblock Electron on a headless/virtualised Windows or Linux CI host
+ * (`--disable-gpu`, `--no-sandbox`, `--disable-software-rasterizer`). Reporting
+ * which of the two attempts succeeded is the point: it distinguishes "the shell
+ * is broken" from "this CI host needs a GPU flag", in a single run.
+ *
+ *   node desktop/electron/test/smoke.mjs
+ *
+ * Exit code 0 means the application loaded.
+ */
+
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { ELECTRON_DIR, WWW_ROOT } from './reporter.mjs';
+
+const requireFromHere = createRequire(import.meta.url);
+
+function electronExecutable() {
+  const pkgDir = path.join(ELECTRON_DIR, 'node_modules', 'electron');
+  if (!existsSync(pkgDir)) throw new Error(`Electron is not installed at ${pkgDir}`);
+  try {
+    return requireFromHere(pkgDir);
+  } catch {
+    const rel = readFileSync(path.join(pkgDir, 'path.txt'), 'utf8').trim();
+    return path.join(pkgDir, 'dist', rel);
+  }
+}
+
+function attempt(label, extraArgs, timeoutMs = 90_000) {
+  return new Promise((resolve) => {
+    const exe = electronExecutable();
+    const userData = mkdtempSync(path.join(tmpdir(), 'scirepl-smoke-'));
+    const args = [ELECTRON_DIR, ...extraArgs];
+
+    console.log(`\n--- attempt: ${label} ---`);
+    console.log(`executable : ${exe}`);
+    console.log(`args       : ${JSON.stringify(args)}`);
+    console.log(`www        : ${WWW_ROOT}`);
+    console.log(`platform   : ${process.platform}-${process.arch}`);
+
+    const child = spawn(exe, args, {
+      env: {
+        ...process.env,
+        SCIREPL_SMOKE_EXIT: '1',
+        SCIREPL_USER_DATA: userData,
+        SCIREPL_WWW: WWW_ROOT,
+        ELECTRON_ENABLE_LOGGING: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let out = '';
+    let err = '';
+    child.stdout.on('data', d => { out += d.toString(); });
+    child.stderr.on('data', d => { err += d.toString(); });
+
+    const timer = setTimeout(() => {
+      console.log(`RESULT     : TIMEOUT after ${timeoutMs}ms — killing`);
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    }, timeoutMs);
+
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      console.log(`RESULT     : SPAWN ERROR ${e.message}`);
+      resolve({ ok: false, label, reason: 'spawn-error' });
+    });
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      // Electron writes a lot of routine noise to stderr; print all of it,
+      // because on a failing CI host the answer is usually in there.
+      if (out.trim()) console.log(`stdout     :\n${out.trim()}`);
+      if (err.trim()) console.log(`stderr     :\n${err.trim()}`);
+      console.log(`RESULT     : exit code=${code} signal=${signal}`);
+
+      const ok = code === 0 && out.includes('SCIREPL_SMOKE_OK');
+      try { rmSync(userData, { recursive: true, force: true }); } catch { /* ignore */ }
+      resolve({ ok, label, code, signal });
+    });
+  });
+}
+
+const plain = await attempt('default (as the test suite launches it)', []);
+if (plain.ok) {
+  console.log('\nSMOKE PASSED — the shell starts and loads the application with default flags.');
+  process.exit(0);
+}
+
+const relaxed = await attempt(
+  'fallback (--disable-gpu --no-sandbox --disable-software-rasterizer)',
+  ['--disable-gpu', '--no-sandbox', '--disable-software-rasterizer']
+);
+
+console.log('\n=== smoke summary ===');
+console.log(`  default flags : ${plain.ok ? 'OK' : 'FAILED'}`);
+console.log(`  relaxed flags : ${relaxed.ok ? 'OK' : 'FAILED'}`);
+
+if (relaxed.ok) {
+  console.log(
+    '\nThe shell itself works; this host needs GPU/sandbox flags to start Electron.\n' +
+    'Fix belongs in the launcher (harness + npm start), not in the application.'
+  );
+} else {
+  console.log(
+    '\nThe shell failed to load under both configurations. The stderr above is the\n' +
+    'main process\'s own output and should name the actual failure.'
+  );
+}
+process.exit(relaxed.ok ? 0 : 1);

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -252,6 +252,42 @@ parity check still fails if Electron ever diverges.
 | External links | `https:`/`mailto:` to the OS; everything else refused; no child window |
 | Offline (network cut) | app starts and reloads; JS, Bash, ClojureScript, Prolog, Python all run; Lua fails cleanly with a clear error; app stays responsive; a bundled kernel still runs afterwards |
 
+### Known divergence from the PWA: the service worker cache is inert
+
+**[verified]** The service worker registers under `app://` (the scheme is
+`secure` and `allowServiceWorkers`), but its caching does not work:
+
+```
+sw.js:97  Uncaught (in promise) TypeError:
+          Failed to execute 'addAll' on 'Cache': Request scheme 'app' is unsupported
+```
+
+The Cache API only accepts `http`/`https` requests, so `www/sw.js`'s app-shell
+precache (`CACHE_VERSION` / `APP_CACHE`) and its CDN runtime cache
+(`CDN_CACHE`) are both non-functional in the shell.
+
+Impact is smaller than it looks, and the measured results already reflect it:
+
+- **App shell** — unaffected in practice. Every local asset is served by the
+  `app://` protocol handler straight off disk, so the precache was redundant
+  here. The offline suite confirms the app starts, reloads and runs its bundled
+  kernels with the network cut **[verified]**.
+- **CDN kernels** — this is the real cost. In the PWA, `CDN_CACHE` is what lets
+  Lua and R work offline after one online use. In the shell they cannot be
+  cached at all, so they need the network every session. That is consistent
+  with, and part of the explanation for, the offline result already reported
+  above (Lua fails cleanly offline).
+
+It also means the "cached" branch of the download-consent check in
+`kernel_manager.js:190-202` never sees a hit under `app://`, so the consent
+modal reappears for CDN kernels every session.
+
+Not a blocker, and deliberately not worked around in Phase 0. The proper fix is
+a platform-appropriate one: a packaged desktop app should bundle its runtimes
+rather than cache CDN downloads — i.e. Windows builds should use a profile that
+bundles Lua and R offline, which is exactly what the existing `pro` profile
+already does for R. Recorded for Phase 2 profile selection (§11).
+
 ### Known divergence from the PWA: the Ko-fi support widget
 
 `www/index.html:407` loads the Ko-fi support widget as a third-party script from
@@ -497,6 +533,7 @@ Risks, in the order they should be addressed:
 | 7 | **CDN download-consent modal on a packaged app.** | Low | Product decision (§5). |
 | 8 | **TypR output gap.** | Low | Pre-existing, reproduces in browser, unrelated to Windows. |
 | 9 | **Ko-fi widget blocked in the shell** (§5). | Low | Deliberate; degrades silently; pinned by tests. Resolve with a shared plain-link change (§11.5), not a CSP exception. |
+| 10 | **Service worker cache inert under `app://`** (§5) — CDN kernels cannot be cached for offline use. | Medium | Fix by bundling runtimes in the Windows profile rather than relying on web caches, which is the right shape for a packaged app anyway. |
 
 ---
 
@@ -564,7 +601,14 @@ the shell, removes a third-party script from the PWA and Android builds too, and
 needs no CSP exception on any platform. Listed here rather than done in this PR
 because it touches shared `www/` code, which the spike deliberately leaves alone.
 
-**6. Keep the artifact boundary test in CI.** It already fails the build if Pro
+**6. Choose a Windows build profile that bundles its runtimes.** The service
+worker cache is inert under `app://` (§5), so a Windows build cannot rely on
+caching CDN downloads for offline use. A packaged desktop application should
+bundle what it needs anyway: define a `windows-free` profile that additionally
+bundles Lua (and, for Pro, R) rather than leaving them on a CDN. This is a
+`build-profiles.json` change, not application code.
+
+**7. Keep the artifact boundary test in CI.** It already fails the build if Pro
 content, a hardcoded `isPro`, a Store licence call, or commerce code appears in
 the shell.
 

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -226,6 +226,40 @@ parity check still fails if Electron ever diverges.
 | External links | `https:`/`mailto:` to the OS; everything else refused; no child window |
 | Offline (network cut) | app starts and reloads; JS, Bash, ClojureScript, Prolog, Python all run; Lua fails cleanly with a clear error; app stays responsive; a bundled kernel still runs afterwards |
 
+### Known divergence from the PWA: the Ko-fi support widget
+
+`www/index.html:407` loads the Ko-fi support widget as a third-party script from
+`https://storage.ko-fi.com`. That origin is **deliberately absent** from the
+shell's CSP allowlist, so the widget is blocked and the support button does not
+render in the Electron build **[verified]**:
+
+```
+securitypolicyviolation  script-src-elem  https://storage.ko-fi.com/cdn/widget/Widget_2.js
+typeof window.kofiwidget2 === "undefined"
+```
+
+The widget is already guarded by `if (typeof kofiwidget2 !== 'undefined')`, so
+blocking it **degrades silently** — nothing throws, and the rest of the Help
+panel is intact **[verified]**.
+
+It is excluded rather than allowed because adding a third-party host to
+`script-src` grants it arbitrary script execution in the same realm that runs
+user notebooks and holds all IndexedDB state (§4). That supply-chain exposure is
+out of proportion to a donate button, and the CSP's entire value here is being
+restrictive about origins.
+
+**This is a divergence, not a fix.** The right resolution is a *shared* change:
+replace the widget with a plain `target="_blank"` link to the Ko-fi page, which
+behaves identically in the PWA, on Android and in the shell, and needs no CSP
+exception anywhere. That touches `www/`, which this spike deliberately does not
+modify, so it is proposed as a Phase 1 follow-up (§11).
+
+Until then the exclusion is pinned by tests — `policy.unit.test.mjs` asserts the
+origin is absent from the allowlist and from the CSP, and `security.test.mjs`
+asserts the live block and its silent degradation — so allowing the origin, or
+dropping the documented exclusion, fails the build and forces the choice to be
+re-made rather than drifting.
+
 ### One behaviour worth calling out for product review
 
 `KernelManager` gates CDN runtime downloads behind a confirmation modal unless
@@ -322,13 +356,13 @@ file the Android build reads was changed. `npm run build:play` and
 
 ## 8. The shell's own test suite
 
-`npm run test:windows` — **verified, 192 assertions, 0 failures**:
+`npm run test:windows` — **verified, 199 assertions, 0 failures**:
 
 | Suite | Result | Needs Electron? |
 | --- | --- | --- |
-| `policy-unit` | 49 passed | no |
+| `policy-unit` | 52 passed | no |
 | `shell-launch` | 18 passed | yes |
-| `security` | 30 passed | yes |
+| `security` | 34 passed | yes |
 | `artifact-boundary` | 14 passed | yes |
 | `download` | 9 passed | yes |
 | `persistence` | 9 passed | yes |
@@ -345,15 +379,33 @@ is tested here. This is the "reuse rather than clone" rule in practice.
 `.github/workflows/windows-electron-spike.yml`, additive, not a required check
 for anything:
 
-- **`shell-policy`** (ubuntu, on PRs touching `desktop/electron/**`) — the 49
+- **`shell-policy`** (ubuntu, on PRs touching `desktop/electron/**`) — the 52
   unit assertions. Needs no display and no Electron download.
   **[verified]** by reproducing the job's exact environment: a tree with only
   `desktop/electron` deps installed via `--ignore-scripts`, no Electron binary,
-  no Playwright → 49/49 passed.
+  no Playwright → 52/52 passed.
 - **`windows-shell`** (windows-latest) — **`workflow_dispatch` only, on purpose.**
   It has never been observed to pass on a Windows runner. Making an unproven,
   ~330 MB-downloading GUI job an automatic gate would block PRs. Promote it to
   `pull_request` after §9 is done.
+
+  This job runs with `SCIREPL_COMPARE_BASELINE=1` and an explicit
+  `npx playwright install chromium` step. Playwright is the shared test driver —
+  `_electron.launch()` drives the shell, `chromium.launch()` drives the browser
+  baseline — and `npm install` provisions the Playwright *package* but not its
+  browser binaries. The two settings go together deliberately: without the
+  baseline flag the suite never calls `chromium.launch()` and the download would
+  be dead weight; with it, the job re-measures the Electron-vs-browser kernel
+  parity of §5 on real Windows rather than inheriting the Linux result.
+
+  **A GitHub constraint affects the merge order.** `workflow_dispatch` is only
+  offered for workflows that already exist on the **default branch**, so a
+  brand-new workflow file cannot be dispatched against its own PR head. Getting
+  a green Windows run *before* merge therefore needs one of: a temporary
+  branch-scoped `push` trigger (what this branch does — clearly marked, and to be
+  removed in the merge commit), merging the workflow file to `main` on its own
+  first, or running §9 by hand on a Windows machine. Without one of those, "run
+  it on the PR, then merge" is not achievable as stated.
 
 ---
 
@@ -417,6 +469,7 @@ Risks, in the order they should be addressed:
 | 6 | **Electron/Chromium upgrade treadmill.** | Low-Medium | Pinned to 43.3.0. Needs a standing update policy, not a one-off. |
 | 7 | **CDN download-consent modal on a packaged app.** | Low | Product decision (§5). |
 | 8 | **TypR output gap.** | Low | Pre-existing, reproduces in browser, unrelated to Windows. |
+| 9 | **Ko-fi widget blocked in the shell** (§5). | Low | Deliberate; degrades silently; pinned by tests. Resolve with a shared plain-link change (§11.5), not a CSP exception. |
 
 ---
 
@@ -477,7 +530,14 @@ with a correct default filename, rather than Electron's default dialog behaviour
 with a materially different desktop implementation, and it needs the Windows
 print verification from §9 first.
 
-**5. Keep the artifact boundary test in CI.** It already fails the build if Pro
+**5. Replace the Ko-fi widget with a plain external link** (§5). A one-line
+change in `www/index.html`: swap the third-party `<script>` for a
+`target="_blank"` anchor to the Ko-fi page. It restores the support button in
+the shell, removes a third-party script from the PWA and Android builds too, and
+needs no CSP exception on any platform. Listed here rather than done in this PR
+because it touches shared `www/` code, which the spike deliberately leaves alone.
+
+**6. Keep the artifact boundary test in CI.** It already fails the build if Pro
 content, a hardcoded `isPro`, a Store licence call, or commerce code appears in
 the shell.
 

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -14,9 +14,35 @@ Two findings change the *shape* of the Phase 1 plan and are described below.
 
 ## 1. Read this first: what "verified" means here
 
-> **All automated results in this document were produced on Linux
-> (WSL2, kernel 6.18, x64) with Electron 43.3.0 / Chromium 150.**
-> **No test in this document was executed on Windows.**
+> **Except where §2.1 says otherwise, all automated results in this document
+> were produced on Linux (WSL2, kernel 6.18, x64) with Electron 43.3.0 /
+> Chromium 150.**
+
+### 2.1 What has now run on Windows
+
+A first `windows-latest` CI run has happened. Partial result:
+
+| Suite | Windows result |
+| --- | --- |
+| `policy-unit` | **52/52 passed on Windows** |
+| everything else | **did not run** — the shell failed to launch |
+
+The Windows `policy-unit` pass is worth more than the Linux one: it exercised
+path containment against real `D:\` drive-letter paths and backslash separators,
+including the percent-encoded traversal cases. Those assertions are now verified
+on the target platform.
+
+The launch failure was a bug in the **test harness**, not the shell: the Electron
+executable path was hardcoded as `dist/electron`, which does not exist on
+Windows (`dist/electron.exe`). Playwright surfaced it only as
+`Error: Process failed to launch!`. Fixed by asking the `electron` package for
+its own platform-specific path — the package resolves it from the `path.txt`
+its installer writes — plus a launch-failure message that reports the
+executable, args and platform instead of failing opaquely.
+
+**The Windows suite has therefore not yet completed. No Electron-dependent
+result in this document is Windows-verified.** The next run on the spike branch
+is the one that settles it.
 
 That is a real limitation and it is not glossed over anywhere below. Every claim
 is tagged:
@@ -424,11 +450,12 @@ node desktop/electron/test/measure.mjs --with-python
 
 Then confirm by hand:
 
-1. **The whole suite passes on Windows.** The only host-specific code is
-   `protocol.js` path handling; `policy.unit.test.mjs` covers Windows separator
-   and drive-letter cases, but has not run on Windows.
+1. **The whole suite passes on Windows.** `policy-unit` already does (§2.1); the
+   seven Electron-dependent suites have not yet completed a Windows run.
 2. **Windows path containment** — that `app://scirepl/..%5C..%5Cpackage.json`
-   (backslash) is refused. `path.relative` is separator-aware, but verify.
+   (backslash) is refused. `policy.unit.test.mjs` now covers drive-letter and
+   backslash cases **on Windows**, but this specific encoded form should be
+   confirmed against the live protocol handler.
 3. **Startup, size and memory re-measured on Windows** — §6 is Linux-only.
    The GPU figure in particular will differ with real hardware acceleration.
 4. **Native Save dialog.** The shell installs no `will-download` handler, so

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -5,55 +5,69 @@ proposed Electron as a Windows-only shell around the existing web application.
 This document records what was **actually built and measured**, using the Free
 edition only.
 
-**Recommendation: proceed to Phase 1.** No incompatibility was found between
-SciREPL and a packaged Electron origin. Every enabled kernel behaves identically
-to the browser baseline, and notebook/SharedVFS state survives a real restart.
-Two findings change the *shape* of the Phase 1 plan and are described below.
+**Recommendation: proceed to Phase 1.** No incompatibility was found that stops
+SciREPL running as a packaged Electron application. Every enabled kernel behaves
+identically to the browser baseline, and notebook/SharedVFS state survives a
+real restart — both now measured on Windows as well as Linux.
+
+Three findings change the *shape* of the Phase 1 plan rather than blocking it:
+the renderer realm boundary (§4), the service worker cache being inert under a
+custom scheme (§5), and the Ko-fi widget divergence (§5). All three are
+described below and reflected in §11.
 
 ---
 
 ## 1. Read this first: what "verified" means here
 
-> **Except where §2.1 says otherwise, all automated results in this document
-> were produced on Linux (WSL2, kernel 6.18, x64) with Electron 43.3.0 /
-> Chromium 150.**
+**The full automated suite now passes on Windows.** The `windows-shell` CI job
+on `windows-latest` (Windows Server 2025) runs all eight suites — **199
+assertions, 0 failures** — including the Playwright Chromium baseline, so the
+kernel-parity result below is measured on Windows and not inherited from Linux.
 
-### 2.1 What has now run on Windows
+Development and the measurements in §6 were done on Linux (WSL2, kernel 6.18,
+x64) with Electron 43.3.0 / Chromium 150. Both platforms produce the same suite
+result.
 
-A first `windows-latest` CI run has happened. Partial result:
+What that does **not** cover is everything a human has to look at: display
+scaling, native dialogs, accessibility, sleep/resume, non-ASCII profile paths.
+Those are still untested and are listed in §9.
 
-| Suite | Windows result |
-| --- | --- |
-| `policy-unit` | **52/52 passed on Windows** |
-| everything else | **did not run** — the shell failed to launch |
-
-The Windows `policy-unit` pass is worth more than the Linux one: it exercised
-path containment against real `D:\` drive-letter paths and backslash separators,
-including the percent-encoded traversal cases. Those assertions are now verified
-on the target platform.
-
-The launch failure was a bug in the **test harness**, not the shell: the Electron
-executable path was hardcoded as `dist/electron`, which does not exist on
-Windows (`dist/electron.exe`). Playwright surfaced it only as
-`Error: Process failed to launch!`. Fixed by asking the `electron` package for
-its own platform-specific path — the package resolves it from the `path.txt`
-its installer writes — plus a launch-failure message that reports the
-executable, args and platform instead of failing opaquely.
-
-**The Windows suite has therefore not yet completed. No Electron-dependent
-result in this document is Windows-verified.** The next run on the spike branch
-is the one that settles it.
-
-That is a real limitation and it is not glossed over anywhere below. Every claim
-is tagged:
+Claims are tagged throughout:
 
 | Tag | Meaning |
 | --- | --- |
-| **[verified]** | An automated test in `desktop/electron/test/` executed and passed. Output quoted or reproducible by running the suite. |
-| **[verified, platform-independent]** | As above, and the behaviour is decided by Chromium/Electron code that does not vary by host OS (origin semantics, storage keying, `webPreferences`, CSP). Windows re-verification is expected to be a formality, but it has not happened. |
-| **[pending Windows]** | Not executed. Listed in §9 with the exact steps to run. |
+| **[verified]** | An automated test in `desktop/electron/test/` executed and passed **on both Linux and Windows CI**. |
+| **[verified, Linux only]** | Executed on Linux; the Windows figure has not been captured. Used for the §6 measurements. |
+| **[pending Windows, manual]** | Requires a human at a Windows desktop. Listed in §9. |
 
-Nothing in this document claims a Windows-only check passed.
+Nothing in this document claims an unexecuted check passed.
+
+### 1.1 How the Windows job got there
+
+Worth recording, because both failures were in the **test harness**, not the
+shell — and both are the kind of thing only a real Windows runner surfaces.
+
+1. **`policy-unit` passed on Windows from the first run** (52/52), which is
+   worth more than the Linux pass: it exercised path containment against real
+   `D:\` drive-letter paths and backslash separators, including the
+   percent-encoded traversal cases.
+2. **Run 1 — Electron would not launch.** The executable path was hardcoded as
+   `dist/electron`; on Windows it is `dist/electron.exe`. Playwright surfaced
+   this only as `Error: Process failed to launch!`. Fixed by asking the
+   `electron` package for its own platform-specific path.
+3. **Run 2 — the process launched but `app` never became ready.** Two causes.
+   `electron@43.3.0` ships **no `postinstall`**; it downloads lazily on first
+   `require()`, so the install step provisioned nothing and the download fired
+   mid-test. And `main.js` called `app.quit()` on a failed single-instance lock
+   and then carried on to register `whenReady` anyway — a process that is
+   quitting but still waiting for `ready` never becomes ready and never exits.
+4. **Run 3 — green.**
+
+The lasting fix is `test/smoke.mjs`: it launches the shell directly, without
+Playwright, and prints the main process's own stdout/stderr, because Playwright
+reports any launch failure as a bare timeout with no output. It runs before the
+suite so its output survives a suite failure. That diagnostic is also what
+surfaced the service-worker limitation in §5.
 
 ---
 
@@ -97,7 +111,7 @@ Registered with `standard`, `secure`, `supportFetchAPI`, `corsEnabled`,
 | `WebAssembly.instantiateStreaming` | fails — no `Content-Type` | **[verified]** `compileStreaming` succeeds |
 | Relative asset resolution | fragile | **[verified]** KaTeX, Marked, Plotly, JSZip, hljs all load |
 
-Measured under the shell **[verified, platform-independent]**:
+Measured under the shell **[verified]** (Linux and Windows CI):
 
 ```
 window.location.origin  === "app://scirepl"     (not "null" — non-opaque)
@@ -146,7 +160,7 @@ notebooks, because a filter would have to tell them apart and cannot.
 
 The shell therefore **withholds capability rather than filtering it**.
 
-### Configuration **[verified, platform-independent]**
+### Configuration **[verified]** (Linux and Windows CI)
 
 | Setting | Value | Asserted from the live window |
 | --- | --- | --- |
@@ -340,7 +354,7 @@ avoid publishing.
 
 ## 6. Measurements
 
-**[verified on Linux/WSL2 x64 — Windows figures must be re-measured, §9]**
+**[verified, Linux only — Windows figures must be re-measured on real hardware, §9]**
 
 ### Size
 
@@ -409,8 +423,8 @@ dependency was added to the web application.
 | `test_sharedvfs_sync.mjs` | passed |
 | `test_notebook_vfs.mjs` | ALL TESTS PASSED |
 
-Android build **[pending Windows/Android toolchain]** — not run here (no Android
-SDK in this environment). The argument that it is unaffected is structural: no
+Android build — **not executed** (no Android SDK in this environment). The
+argument that it is unaffected is structural rather than empirical: no
 file the Android build reads was changed. `npm run build:play` and
 `build-release.yml` are byte-identical to `main`.
 
@@ -446,69 +460,81 @@ for anything:
   **[verified]** by reproducing the job's exact environment: a tree with only
   `desktop/electron` deps installed via `--ignore-scripts`, no Electron binary,
   no Playwright → 52/52 passed.
-- **`windows-shell`** (windows-latest) — **`workflow_dispatch` only, on purpose.**
-  It has never been observed to pass on a Windows runner. Making an unproven,
-  ~330 MB-downloading GUI job an automatic gate would block PRs. Promote it to
-  `pull_request` after §9 is done.
+- **`windows-shell`** (windows-latest, on PRs touching `desktop/electron/**`,
+  plus `workflow_dispatch`) — **verified green:** all eight suites, 199
+  assertions, 0 failures, all eight kernels at browser parity.
 
-  This job runs with `SCIREPL_COMPARE_BASELINE=1` and an explicit
+  It runs with `SCIREPL_COMPARE_BASELINE=1` and an explicit
   `npx playwright install chromium` step. Playwright is the shared test driver —
   `_electron.launch()` drives the shell, `chromium.launch()` drives the browser
   baseline — and `npm install` provisions the Playwright *package* but not its
   browser binaries. The two settings go together deliberately: without the
   baseline flag the suite never calls `chromium.launch()` and the download would
-  be dead weight; with it, the job re-measures the Electron-vs-browser kernel
-  parity of §5 on real Windows rather than inheriting the Linux result.
+  be dead weight; with it, the job measures Electron-vs-browser kernel parity on
+  real Windows rather than inheriting the Linux result.
 
-  **A GitHub constraint affects the merge order.** `workflow_dispatch` is only
-  offered for workflows that already exist on the **default branch**, so a
-  brand-new workflow file cannot be dispatched against its own PR head. Getting
-  a green Windows run *before* merge therefore needs one of: a temporary
-  branch-scoped `push` trigger (what this branch does — clearly marked, and to be
-  removed in the merge commit), merging the workflow file to `main` on its own
-  first, or running §9 by hand on a Windows machine. Without one of those, "run
-  it on the PR, then merge" is not achievable as stated.
+  A `smoke.mjs` step runs first and prints the main process's own
+  stdout/stderr, because Playwright reports any launch failure as a bare
+  timeout. Keep it: it is what made the two Windows-only harness bugs in §1.1
+  diagnosable, and it surfaced the service-worker finding in §5.
+
+  It reaches CDN hosts for the baseline comparison, so it carries some network
+  flakiness risk. If that becomes noise, drop it back to `workflow_dispatch`
+  rather than tolerating a habitually red job.
+
+  **A note for anyone adding a workflow like this in future.**
+  `workflow_dispatch` is only offered for workflows that already exist on the
+  **default branch**, so a brand-new workflow file cannot be dispatched against
+  its own PR head — "run it on the PR, then merge" is not achievable as stated.
+  This branch used a temporary branch-scoped `push` trigger to get a green run
+  before merge; it has been removed now that the job runs on `pull_request`.
 
 ---
 
-## 9. Remaining Windows-only manual verification
+## 9. Remaining Windows verification
 
-None of these were executed. Run on a Windows 10/11 x64 machine:
+The automated suite is covered — it passes on `windows-latest` in CI (§1). What
+remains needs a human at a Windows desktop, or a physical machine rather than a
+CI VM. **None of the following has been executed.**
+
+To reproduce the automated run locally on Windows 10/11 x64:
 
 ```powershell
 npm install
 npm run configure
 npm run fetch:bundles
 npm run windows:install
-npm run test:windows          # expect the §8 table
+node desktop/electron/test/smoke.mjs   # direct launch + raw main-process output
+npm run test:windows                   # expect the §8 table
 node desktop/electron/test/measure.mjs --with-python
 ```
 
 Then confirm by hand:
 
-1. **The whole suite passes on Windows.** `policy-unit` already does (§2.1); the
-   seven Electron-dependent suites have not yet completed a Windows run.
-2. **Windows path containment** — that `app://scirepl/..%5C..%5Cpackage.json`
-   (backslash) is refused. `policy.unit.test.mjs` now covers drive-letter and
-   backslash cases **on Windows**, but this specific encoded form should be
-   confirmed against the live protocol handler.
-3. **Startup, size and memory re-measured on Windows** — §6 is Linux-only.
-   The GPU figure in particular will differ with real hardware acceleration.
-4. **Native Save dialog.** The shell installs no `will-download` handler, so
+1. **Windows path containment against the live handler** — that
+   `app://scirepl/..%5C..%5Cpackage.json` (encoded backslash) is refused.
+   `policy.unit.test.mjs` covers drive-letter and backslash cases on Windows,
+   but this specific encoded form is only asserted against `resolveRequestPath`,
+   not the running protocol handler.
+2. **Startup, size and memory re-measured on Windows** — §6 is Linux-only, and
+   the GPU figure in particular will differ with real hardware acceleration.
+   A CI VM is not a fair sample either; use a real machine.
+3. **Native Save dialog.** The shell installs no `will-download` handler, so
    Electron shows its default Save dialog. Confirm each export format
    (HTML, Markdown, LaTeX, DOCX, PDF, `.srwb`, `.ipynb`) reaches disk with a
    correct default filename and extension.
-5. **PDF export** — the browser `window.print()` path; the Capacitor
+4. **PDF export** — the browser `window.print()` path; the Capacitor
    `PdfGenerator` plugin is absent here.
-6. **External links** open in the default Windows browser and focus it.
-7. **Display scaling** (125/150/200%), high contrast, keyboard-only navigation,
+5. **External links** open in the default Windows browser and focus it.
+6. **Display scaling** (125/150/200%), high contrast, keyboard-only navigation,
    and a screen reader (Narrator/NVDA).
-8. **Sleep/resume** with a kernel loaded; **shutdown while a kernel is running**.
-9. **Long paths / non-ASCII usernames** — `userData` under a profile such as
+7. **Sleep/resume** with a kernel loaded; **shutdown while a kernel is running**.
+8. **Long paths / non-ASCII usernames** — `userData` under a profile such as
    `C:\Users\Ünïcode\AppData\Roaming\SciREPL-Free-Electron`.
-10. **Second-instance behaviour** — the single-instance lock focuses the existing
-    window rather than opening a second renderer on the same IndexedDB.
-11. **arm64**, if offered.
+9. **Second-instance behaviour — the focus half.** That a losing instance exits
+   promptly rather than hanging is verified (§1.1); that it *focuses the
+   existing window* is not, and needs a visible desktop.
+10. **arm64**, if offered.
 
 Explicitly **not** attempted, per the brief: MSIX packaging, Store submission,
 `StoreContext.GetAppLicenseAsync()`, and anything Pro.
@@ -526,7 +552,7 @@ Risks, in the order they should be addressed:
 | --- | --- | --- | --- |
 | 1 | **Notebook code shares the renderer realm with UI code.** Any future native operation exposed to the main world is callable by a notebook cell. | **High — architectural** | Contained today (nothing exposed carries authority). Becomes the central constraint the moment `saveFile`/`openFile` are added. See §11. |
 | 2 | **Electron runtime size** — 327 MB unpacked on Linux, plus 108 MB of `www/`. | Medium | Known, and exactly the Phase 4 Tauri trigger. Not a Phase 0 blocker. |
-| 3 | **Windows entirely unverified.** | Medium | Structural argument is strong (Chromium-level behaviour), but §9 must be done before Phase 2. |
+| 3 | **No human has used it on Windows.** The automated suite passes on windows-latest, but display scaling, native dialogs, accessibility and sleep/resume are untested. | Medium | §9 must be done before Phase 2. |
 | 4 | **Memory footprint** — ~0.9 GB with Pyodide loaded, on inflated Linux metrics. | Medium | Needs honest Windows numbers before any Store claim about system requirements. |
 | 5 | **`'unsafe-eval'` is mandatory.** | Low-Medium | Unavoidable — the product is a REPL. Documented and asserted. Compensate by restricting origins and keeping Chromium current. |
 | 6 | **Electron/Chromium upgrade treadmill.** | Low-Medium | Pinned to 43.3.0. Needs a standing update policy, not a one-off. |
@@ -626,9 +652,9 @@ anything. None is justified by a Phase 0 observation.
 | --- | --- |
 | All important WASM kernels work in the packaged origin | ✅ **[verified]** 8/8, at parity with the browser |
 | Notebook code cannot cross the native bridge | ✅ **[verified]** — and there is almost no bridge to cross |
-| IndexedDB and SharedVFS survive | ✅ **[verified]** across a real restart; across an *MSIX update* is **[pending Windows]** |
+| IndexedDB and SharedVFS survive | ✅ **[verified]** across a real restart, on Linux and Windows CI; across an *MSIX update* is untested |
 | The same web bundle still runs under Capacitor without a fork | ✅ `www/` unchanged; existing browser tests pass |
-| Offline assets fit practical Store limits | ⚠️ measured (108 MB + runtime) but Windows/MSIX figures **[pending Windows]** |
+| Offline assets fit practical Store limits | ⚠️ measured on Linux (108 MB + runtime); Windows/MSIX figures still to be captured (§9) |
 | Expected Windows demand justifies the cost | ❌ out of scope — a product judgement, not a spike output |
 
 **Recommendation: proceed to Phase 1**, starting with the realm-boundary decision

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -1,0 +1,505 @@
+# Phase 0: Windows Electron feasibility spike — results
+
+Companion to [`WINDOWS_STORE_PROPOSAL.md`](WINDOWS_STORE_PROPOSAL.md), which
+proposed Electron as a Windows-only shell around the existing web application.
+This document records what was **actually built and measured**, using the Free
+edition only.
+
+**Recommendation: proceed to Phase 1.** No incompatibility was found between
+SciREPL and a packaged Electron origin. Every enabled kernel behaves identically
+to the browser baseline, and notebook/SharedVFS state survives a real restart.
+Two findings change the *shape* of the Phase 1 plan and are described below.
+
+---
+
+## 1. Read this first: what "verified" means here
+
+> **All automated results in this document were produced on Linux
+> (WSL2, kernel 6.18, x64) with Electron 43.3.0 / Chromium 150.**
+> **No test in this document was executed on Windows.**
+
+That is a real limitation and it is not glossed over anywhere below. Every claim
+is tagged:
+
+| Tag | Meaning |
+| --- | --- |
+| **[verified]** | An automated test in `desktop/electron/test/` executed and passed. Output quoted or reproducible by running the suite. |
+| **[verified, platform-independent]** | As above, and the behaviour is decided by Chromium/Electron code that does not vary by host OS (origin semantics, storage keying, `webPreferences`, CSP). Windows re-verification is expected to be a formality, but it has not happened. |
+| **[pending Windows]** | Not executed. Listed in §9 with the exact steps to run. |
+
+Nothing in this document claims a Windows-only check passed.
+
+---
+
+## 2. What was built
+
+A thin shell under `desktop/electron/`, ~126 kB of source, five files:
+
+| File | Role |
+| --- | --- |
+| `main.js` | lifecycle, window creation, single-instance lock, storage flush on quit |
+| `protocol.js` | the `app://scirepl` scheme, MIME map, path containment, CSP |
+| `security.js` | navigation / window-open / permission policy |
+| `preload.js` | the entire renderer-visible surface — two read-only calls |
+| `ipc.js` | the canonical IPC allowlist, owned by the main process |
+
+It loads the **unmodified** prepared `www/` tree. No file under `www/`,
+`android/`, `scripts/`, or `capacitor.config.json` was changed (§7).
+
+Electron lives in `desktop/electron/package.json`, **not** the root
+`package.json`, so a root `npm install` — what the Android build and existing CI
+do — does not download a ~220 MB Chromium runtime. Electron is pinned exactly to
+`43.3.0`.
+
+---
+
+## 3. Origin/protocol decision
+
+**Decision: a custom standard scheme, `app://scirepl/`, not `file://`.**
+
+Registered with `standard`, `secure`, `supportFetchAPI`, `corsEnabled`,
+`stream`, `allowServiceWorkers`, `codeCache`.
+
+`file://` was rejected on concrete grounds, not preference. It gives documents an
+**opaque** origin, and SciREPL is origin-sensitive in five separate ways:
+
+| Requirement | Under `file://` | Under `app://scirepl` |
+| --- | --- | --- |
+| IndexedDB (notebooks, SharedVFS) | unreliable / unpartitioned | **[verified]** survives restart |
+| Service worker registration | impossible (opaque origin) | supported (scheme is `secure`) |
+| `fetch()` of relative URLs | blocked | **[verified]** works |
+| `WebAssembly.instantiateStreaming` | fails — no `Content-Type` | **[verified]** `compileStreaming` succeeds |
+| Relative asset resolution | fragile | **[verified]** KaTeX, Marked, Plotly, JSZip, hljs all load |
+
+Measured under the shell **[verified, platform-independent]**:
+
+```
+window.location.origin  === "app://scirepl"     (not "null" — non-opaque)
+window.isSecureContext  === true
+fetch('js/kernel_config.js')      200 text/javascript
+fetch('vendor/brush/brush_wasm_bg.wasm')  200 application/wasm
+WebAssembly.compileStreaming(...)  resolves
+```
+
+`protocol.js` is the only code that maps a URL to a file, and it refuses
+traversal in raw and percent-encoded forms (`/../`, `/%2e%2e/`, `/..%2f`,
+`%00`, malformed `%ZZ`) **[verified]**, plus the prefix-confusion case where a
+sibling path merely starts with the root's name.
+
+### A real bug this decision surfaced
+
+`security.js` originally classified in-app navigation by comparing
+`url.origin === 'app://scirepl'`. That is wrong in the **main process**:
+`registerSchemesAsPrivileged({standard:true})` teaches *Chromium* the scheme, but
+the main process parses URLs with **Node's** implementation, which has no such
+registry and reports `origin === 'null'` for a non-special scheme. The
+`will-navigate` handler would therefore have classified every in-app navigation
+as external and blocked the app from navigating within itself.
+
+Caught by `policy.unit.test.mjs`, confirmed by running both parsers, and fixed by
+comparing `protocol` + `hostname`. `security.test.mjs` now asserts in-app
+navigation is *permitted*, not merely that external navigation is blocked.
+Worth recording because any future custom-scheme logic in the main process has
+the same trap.
+
+---
+
+## 4. Security model
+
+### The finding that drives the design
+
+SciREPL's JavaScript kernel executes notebook cells with
+`new AsyncFunction(code)` **in the main renderer realm**
+(`www/js/kernels/javascript.js:70-71`). Scittle, Fengari and Pyodide's JS bridge
+reach the same `window`. There is **no realm boundary between SciREPL's own UI
+code and user-authored notebook code**.
+
+Consequence: any preload API exposed to the main world is reachable by a
+notebook cell. A capability cannot be given to the app but withheld from
+notebooks, because a filter would have to tell them apart and cannot.
+
+The shell therefore **withholds capability rather than filtering it**.
+
+### Configuration **[verified, platform-independent]**
+
+| Setting | Value | Asserted from the live window |
+| --- | --- | --- |
+| `nodeIntegration` | `false` | ✔ (also workers, sub-frames) |
+| `contextIsolation` | `true` | ✔ |
+| `sandbox` | `true` | ✔ (OS sandbox on; suite records if relaxed) |
+| `webSecurity` | enabled | ✔ |
+| `webviewTag` | `false` | ✔ |
+| `@electron/remote` | not installed | ✔ |
+
+### Regression tests written from the attacker's position **[verified]**
+
+Executed **through the real JavaScript kernel**, i.e. as a notebook cell:
+
+- `require`, `process`, `Buffer`, `module`, `__dirname`, `global`, `electron`,
+  `ipcRenderer` → all `ReferenceError`.
+- `new Function('return process')()`, `top.require`, `parent.require` → all blocked.
+- The exposed surface is exactly `['getAppInfo','getDistributionInfo']`, frozen.
+- No `invoke`/`send`/`on`/`ipc`/`fs`/`shell`/`exec`/`readFile`/`writeFile` of any name.
+- A cell setting `window.location.href = 'https://example.com/'` does not move the window.
+- A cell calling `window.open('https://example.com/')` creates **no** second window.
+- Renderer-supplied arguments to the platform API are inert.
+
+### The exposed surface, and why it is only two calls
+
+`getAppInfo()` and `getDistributionInfo()` are nullary and return static build
+facts. They carry no authority and are safe when called by hostile notebook code
+— which is the standard every future operation must meet.
+
+Not exposed, deliberately: a generic `invoke`, any filesystem or shell
+operation, and `openExternal`. External links are plain `target="_blank"`
+anchors (`www/index.html:140,396,897`), so `setWindowOpenHandler` in the **main
+process** handles them: `https:`/`mailto:` only, no credentials in the URL, and
+the window is always denied. `file:`, `javascript:`, `data:`, `vbscript:`,
+`ms-settings:` and `shell:` are all refused **[verified]**. This is parity with
+a browser, where page JS can already open a tab — not an escalation.
+
+`getDistributionInfo()` returns `store: null`. No entitlement system was
+implemented, faked, or stubbed. The `StoreContext.GetAppLicenseAsync()` seam is
+documented in `ipc.js` as a comment only; `artifact-boundary.test.mjs` fails the
+build if it is ever implemented in shell source **[verified]**.
+
+### CSP
+
+Applied by the protocol handler to documents and scripts, so `www/index.html` is
+**unchanged** and the PWA is unaffected. Restrictive about origins
+(`object-src 'none'`, `frame-ancestors 'none'`, `form-action 'none'`,
+`base-uri 'self'`, no plaintext `http:`), with the remote allowlist derived from
+`build-profiles.json` and `package_catalog.js` rather than guessed.
+
+`'unsafe-eval'` and `'wasm-unsafe-eval'` are permitted and **cannot be removed** —
+the JavaScript kernel, Scittle and Pyodide all require them. Unit tests assert
+their presence so removing them is a conscious decision, and assert the origin
+restrictions so they cannot be loosened silently. The CSP is defence in depth;
+the boundary is `contextIsolation` + `sandbox` + the absent API.
+
+---
+
+## 5. Compatibility results
+
+Every kernel enabled by the Free `full` profile, driven through the
+application's own `kernelManager.ensureReady()` / `.execute()`. The **same probe
+module** (`test/probes/kernels.mjs`) is run by the Electron runner and by a plain
+Chromium runner against the repo's own `server.js`, so a difference in results is
+a real platform difference rather than two divergent suites.
+
+**[verified]** — Electron 43.3.0 vs Chromium baseline, Free `full` profile:
+
+| Kernel | Source | Electron init / exec | Browser init / exec | Parity |
+| --- | --- | --- | --- | --- |
+| JavaScript (native) | — | 0 ms / 1 ms | 0 ms / 1 ms | ✅ |
+| Bash / Brush (WASM) | bundled | 222 ms / 12 ms | 176 ms / 16 ms | ✅ |
+| TypR (WASM + webR) | bundled + CDN | runs; output gap¹ | runs; output gap¹ | ✅ identical |
+| Lua / Fengari | CDN | 133 ms / 2 ms | 144 ms / 6 ms | ✅ |
+| ClojureScript / Scittle | bundled | 64 ms / 18 ms | 57 ms / 13 ms | ✅ |
+| SWI-Prolog (WASM) | bundled | 1136 ms / 4 ms | 943 ms / 5 ms | ✅ |
+| Python / Pyodide (WASM) | bundled | 8187 ms / 3 ms | 9614 ms / 6 ms | ✅ |
+| R / webR (WASM) | CDN in Free | runs / 19 ms | runs / 20 ms | ✅ |
+
+**No kernel behaves differently under the packaged origin.**
+
+¹ TypR initialises and executes without error, but `cat()` output does not reach
+`execute()`'s stdout. This reproduces **identically** in the browser baseline,
+and the repository's own `test_typr_kernel.mjs` already tolerates empty output
+here — so it is a pre-existing application gap, not something Electron
+introduced. It is reported as a known gap rather than silently relaxed, and the
+parity check still fails if Electron ever diverges.
+
+### Other features **[verified]**
+
+| Feature | Result |
+| --- | --- |
+| Startup + reload | app boots and reloads at the same origin; no uncaught page errors |
+| Workers | Pyodide/webR worker-backed kernels run under `app://` |
+| Cross-kernel SharedVFS | write via `sharedVFS` → readable from the Python kernel |
+| SharedVFS → IndexedDB | persisted; DBs created: `scirepl_vfs`, `emscripten_filesystem` |
+| IndexedDB across restart | marker survives a real process restart |
+| localStorage across restart | survives |
+| Shutdown during active writes | graceful close, no SIGKILL needed |
+| Export delivery | `FileIO._downloadBlob` → blob URL → download reaches main process, bytes intact on disk |
+| Import primitives | `File`/`FileReader` work under `app://` |
+| Blob URLs | creatable and readable under `app://` |
+| External links | `https:`/`mailto:` to the OS; everything else refused; no child window |
+| Offline (network cut) | app starts and reloads; JS, Bash, ClojureScript, Prolog, Python all run; Lua fails cleanly with a clear error; app stays responsive; a bundled kernel still runs afterwards |
+
+### One behaviour worth calling out for product review
+
+`KernelManager` gates CDN runtime downloads behind a confirmation modal unless
+`localStorage['scirepl_auto_download'] === '1'`
+(`www/js/kernel_manager.js:202`). This is correct for the PWA. In a **packaged
+desktop app** it means a first-run user who clicks the Lua or R kernel gets a
+download-consent dialog, which reads differently from an installed application.
+
+This is a product decision for Phase 2, not a blocker. Noting it because it also
+cost real debugging time here: the first matrix run showed Lua, R and TypR
+"timing out" for 240 s each. That was the harness failing to grant consent, not
+an Electron incompatibility — the kind of false negative this report is meant to
+avoid publishing.
+
+---
+
+## 6. Measurements
+
+**[verified on Linux/WSL2 x64 — Windows figures must be re-measured, §9]**
+
+### Size
+
+| Item | Size |
+| --- | --- |
+| Prepared `www/` (Free `full`) | **108.3 MB** (`vendor/` 96.1 MB) |
+| — `vendor/pyodide` | 72.4 MB |
+| — `vendor/swipl` | 11.0 MB |
+| — `vendor/brush` | 6.5 MB |
+| — `vendor/typr` | 2.6 MB |
+| — `vendor/katex` + `plotly` + `scittle` + rest | 3.6 MB |
+| Electron runtime (`dist/`, Linux x64) | **327.4 MB** unpacked |
+| Shell source | 126.3 kB |
+
+An installed Windows Free build is therefore roughly **`www/` + the Windows
+Electron runtime**, before any installer compression. The Electron runtime is
+the dominant cost and is exactly what the proposal's Phase 4 Tauri question is
+about. Note the Pro profile adds webR offline (~50 MB more) on top.
+
+### Startup
+
+| Measure | Value |
+| --- | --- |
+| Process launch → first window | 1339 ms |
+| Process launch → app ready (`kernelManager` present) | 1398 ms |
+| In-page DOMContentLoaded | 263–451 ms across runs |
+
+### Memory (`app.getAppMetrics()`, 4 processes)
+
+| State | Total | Breakdown |
+| --- | --- | --- |
+| Idle, app loaded | 668.3 MB | Browser 197, GPU 202.7, Utility 90.7, Tab 177.9 |
+| After Pyodide loaded | 936.0 MB | Browser 240.3, GPU 228, Utility 90.7, Tab 376.9 |
+
+**Treat these as indicative only.** `workingSetSize` counts shared pages against
+every process, so the total overstates real consumption, and the GPU figure is
+inflated by WSLg's software rendering path. The *shape* — Pyodide adding ~200 MB
+to the renderer — is the reliable signal. Absolute numbers need Windows.
+
+---
+
+## 7. Android / PWA regression status
+
+**No shared runtime file was modified.** Complete diff against `main`:
+
+| Change | Nature |
+| --- | --- |
+| `desktop/**` (new) | Windows-only, referenced by nothing else |
+| `.github/workflows/windows-electron-spike.yml` (new) | additive workflow |
+| `package.json` | **+4 scripts only** (`windows:install`, `dev:windows`, `test:windows`, `test:windows:unit`) |
+| `.gitignore` | +4 ignore rules for Electron output |
+| `docs/WINDOWS_ELECTRON_SPIKE.md` (new) | this file |
+
+Untouched: `www/**`, `android/**`, `capacitor.config.json`, `build-profiles.json`,
+`scripts/**`, `server.js`, `sw.js`, root `package-lock.json`, every existing
+`npm` script and both existing workflows. No Android application ID, version,
+Gradle setting, runtime version or bundled artifact changed. No production
+dependency was added to the web application.
+
+### Existing browser tests re-run unchanged **[verified]**
+
+| Test | Result |
+| --- | --- |
+| `test_js_kernel.mjs` | 13/13 passed |
+| `test_lua_kernel.mjs` | ALL TESTS PASSED |
+| `test_sharedvfs_sync.mjs` | passed |
+| `test_notebook_vfs.mjs` | ALL TESTS PASSED |
+
+Android build **[pending Windows/Android toolchain]** — not run here (no Android
+SDK in this environment). The argument that it is unaffected is structural: no
+file the Android build reads was changed. `npm run build:play` and
+`build-release.yml` are byte-identical to `main`.
+
+---
+
+## 8. The shell's own test suite
+
+`npm run test:windows` — **verified, 192 assertions, 0 failures**:
+
+| Suite | Result | Needs Electron? |
+| --- | --- | --- |
+| `policy-unit` | 49 passed | no |
+| `shell-launch` | 18 passed | yes |
+| `security` | 30 passed | yes |
+| `artifact-boundary` | 14 passed | yes |
+| `download` | 9 passed | yes |
+| `persistence` | 9 passed | yes |
+| `kernels` | 46 passed, 2 known-gap skips | yes |
+| `offline` | 17 passed | yes |
+
+Export *correctness* is deliberately **not** re-tested — the existing browser
+tests already cover which bytes each format produces, and that logic is
+platform-independent. Only the delivery step, which Electron genuinely changes,
+is tested here. This is the "reuse rather than clone" rule in practice.
+
+### CI
+
+`.github/workflows/windows-electron-spike.yml`, additive, not a required check
+for anything:
+
+- **`shell-policy`** (ubuntu, on PRs touching `desktop/electron/**`) — the 49
+  unit assertions. Needs no display and no Electron download.
+  **[verified]** by reproducing the job's exact environment: a tree with only
+  `desktop/electron` deps installed via `--ignore-scripts`, no Electron binary,
+  no Playwright → 49/49 passed.
+- **`windows-shell`** (windows-latest) — **`workflow_dispatch` only, on purpose.**
+  It has never been observed to pass on a Windows runner. Making an unproven,
+  ~330 MB-downloading GUI job an automatic gate would block PRs. Promote it to
+  `pull_request` after §9 is done.
+
+---
+
+## 9. Remaining Windows-only manual verification
+
+None of these were executed. Run on a Windows 10/11 x64 machine:
+
+```powershell
+npm install
+npm run configure
+npm run fetch:bundles
+npm run windows:install
+npm run test:windows          # expect the §8 table
+node desktop/electron/test/measure.mjs --with-python
+```
+
+Then confirm by hand:
+
+1. **The whole suite passes on Windows.** The only host-specific code is
+   `protocol.js` path handling; `policy.unit.test.mjs` covers Windows separator
+   and drive-letter cases, but has not run on Windows.
+2. **Windows path containment** — that `app://scirepl/..%5C..%5Cpackage.json`
+   (backslash) is refused. `path.relative` is separator-aware, but verify.
+3. **Startup, size and memory re-measured on Windows** — §6 is Linux-only.
+   The GPU figure in particular will differ with real hardware acceleration.
+4. **Native Save dialog.** The shell installs no `will-download` handler, so
+   Electron shows its default Save dialog. Confirm each export format
+   (HTML, Markdown, LaTeX, DOCX, PDF, `.srwb`, `.ipynb`) reaches disk with a
+   correct default filename and extension.
+5. **PDF export** — the browser `window.print()` path; the Capacitor
+   `PdfGenerator` plugin is absent here.
+6. **External links** open in the default Windows browser and focus it.
+7. **Display scaling** (125/150/200%), high contrast, keyboard-only navigation,
+   and a screen reader (Narrator/NVDA).
+8. **Sleep/resume** with a kernel loaded; **shutdown while a kernel is running**.
+9. **Long paths / non-ASCII usernames** — `userData` under a profile such as
+   `C:\Users\Ünïcode\AppData\Roaming\SciREPL-Free-Electron`.
+10. **Second-instance behaviour** — the single-instance lock focuses the existing
+    window rather than opening a second renderer on the same IndexedDB.
+11. **arm64**, if offered.
+
+Explicitly **not** attempted, per the brief: MSIX packaging, Store submission,
+`StoreContext.GetAppLicenseAsync()`, and anything Pro.
+
+---
+
+## 10. Blockers and risks
+
+**Blockers: none.** Nothing was found that would prevent SciREPL running as a
+standalone Electron application.
+
+Risks, in the order they should be addressed:
+
+| # | Risk | Severity | Assessment |
+| --- | --- | --- | --- |
+| 1 | **Notebook code shares the renderer realm with UI code.** Any future native operation exposed to the main world is callable by a notebook cell. | **High — architectural** | Contained today (nothing exposed carries authority). Becomes the central constraint the moment `saveFile`/`openFile` are added. See §11. |
+| 2 | **Electron runtime size** — 327 MB unpacked on Linux, plus 108 MB of `www/`. | Medium | Known, and exactly the Phase 4 Tauri trigger. Not a Phase 0 blocker. |
+| 3 | **Windows entirely unverified.** | Medium | Structural argument is strong (Chromium-level behaviour), but §9 must be done before Phase 2. |
+| 4 | **Memory footprint** — ~0.9 GB with Pyodide loaded, on inflated Linux metrics. | Medium | Needs honest Windows numbers before any Store claim about system requirements. |
+| 5 | **`'unsafe-eval'` is mandatory.** | Low-Medium | Unavoidable — the product is a REPL. Documented and asserted. Compensate by restricting origins and keeping Chromium current. |
+| 6 | **Electron/Chromium upgrade treadmill.** | Low-Medium | Pinned to 43.3.0. Needs a standing update policy, not a one-off. |
+| 7 | **CDN download-consent modal on a packaged app.** | Low | Product decision (§5). |
+| 8 | **TypR output gap.** | Low | Pre-existing, reproduces in browser, unrelated to Windows. |
+
+---
+
+## 11. Proposed Phase 1 plan
+
+Scoped to what this spike **actually observed**, not to the full interface
+sketched in the proposal.
+
+### The central observation
+
+Phase 0 needed **zero** changes to `www/` — because every existing
+`window.Capacitor` call site already has a working browser fallback, and Electron
+takes it:
+
+| Site | Capacitor path | Browser fallback (what Electron uses) |
+| --- | --- | --- |
+| `file_io.js:80` | `Browser.open` | button hidden when absent |
+| `file_io.js:749` | `Filesystem` + `Share` | blob URL + `<a download>` |
+| `file_io.js:1330` | `Filesystem` + `Share` | blob URL download |
+| `export.js:1143` | `PdfGenerator` | `window.print()` |
+| `export.js:1905` | `Filesystem` + `Share` | blob URL download |
+| `package_catalog.js:654` | native HTTP | `fetch()` |
+
+**So Phase 1 should not be a general "abstract Capacitor away" refactor.** The
+proposal's full six-operation interface is not yet justified by evidence — the
+browser fallbacks work. Introducing an abstraction over six operations to
+replace six working conditionals would be motion, not progress.
+
+### What Phase 1 should actually do
+
+**1. Fix the realm boundary first (risk #1).** This is the only finding that
+blocks a *safe* native operation, so it precedes any platform interface. Either:
+
+- run notebook JavaScript in a Worker or sandboxed iframe so it no longer shares
+  `window` with UI code — the durable fix, and it also benefits Android and the
+  PWA; **or**
+- accept the shared realm permanently and require **every** native operation to
+  be user-confirmed through an OS dialog, so hostile notebook code can at worst
+  cause a dialog the user must accept.
+
+Decide this explicitly. Do not add `saveFile` before it is decided.
+
+**2. Introduce the platform interface for exactly two operations**, the two where
+the browser fallback is genuinely worse on desktop:
+
+- `saveFile(name, bytes, mediaType)` → native Save As. Must show the OS dialog,
+  so the *user* chooses the path, which also satisfies option (b) above.
+- `openFile(filters)` → native Open, plus drag-and-drop import.
+
+Three adapters (browser, Capacitor, Electron), contract tests per adapter.
+Everything else keeps its working browser path until evidence says otherwise.
+
+**3. Add a `will-download` handler** to the shell so exports get a proper Save As
+with a correct default filename, rather than Electron's default dialog behaviour
+(§9 item 4).
+
+**4. Migrate `export.js:1143` (`PdfGenerator`) last.** It is the one call site
+with a materially different desktop implementation, and it needs the Windows
+print verification from §9 first.
+
+**5. Keep the artifact boundary test in CI.** It already fails the build if Pro
+content, a hardcoded `isPro`, a Store licence call, or commerce code appears in
+the shell.
+
+### Explicitly deferred
+
+`shareFile`, `openExternal` as an exposed op (the window-open handler covers it),
+`getDistributionInfo` growing entitlement meaning, MSIX, Store licensing, Pro
+anything. None is justified by a Phase 0 observation.
+
+---
+
+## 12. Decision gates from the proposal
+
+| Gate | Status |
+| --- | --- |
+| All important WASM kernels work in the packaged origin | ✅ **[verified]** 8/8, at parity with the browser |
+| Notebook code cannot cross the native bridge | ✅ **[verified]** — and there is almost no bridge to cross |
+| IndexedDB and SharedVFS survive | ✅ **[verified]** across a real restart; across an *MSIX update* is **[pending Windows]** |
+| The same web bundle still runs under Capacitor without a fork | ✅ `www/` unchanged; existing browser tests pass |
+| Offline assets fit practical Store limits | ⚠️ measured (108 MB + runtime) but Windows/MSIX figures **[pending Windows]** |
+| Expected Windows demand justifies the cost | ❌ out of scope — a product judgement, not a spike output |
+
+**Recommendation: proceed to Phase 1**, starting with the realm-boundary decision
+(§11.1) rather than with a broad platform-interface refactor. Do not proceed to
+MSIX, Store submission or Pro work until §9 has been executed on real Windows.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build:release:aab": "npm run configure && npm run fetch:bundles && npx cap sync && cd android && ./gradlew bundleRelease",
         "build:release:apk": "npm run configure && npm run fetch:bundles && npx cap sync && cd android && ./gradlew assembleRelease",
         "build:play": "npm run build:release:aab",
-        "windows:install": "npm --prefix desktop/electron install",
+        "windows:install": "npm --prefix desktop/electron install && node desktop/electron/node_modules/electron/install.js",
         "dev:windows": "npm run configure && npm run fetch:bundles && npm --prefix desktop/electron start",
         "test:windows": "node desktop/electron/test/run-all.mjs",
         "test:windows:unit": "node desktop/electron/test/run-all.mjs --unit"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
         "build:debug": "npm run configure && npm run fetch:bundles && npx cap sync && cd android && ./gradlew assembleDebug",
         "build:release:aab": "npm run configure && npm run fetch:bundles && npx cap sync && cd android && ./gradlew bundleRelease",
         "build:release:apk": "npm run configure && npm run fetch:bundles && npx cap sync && cd android && ./gradlew assembleRelease",
-        "build:play": "npm run build:release:aab"
+        "build:play": "npm run build:release:aab",
+        "windows:install": "npm --prefix desktop/electron install",
+        "dev:windows": "npm run configure && npm run fetch:bundles && npm --prefix desktop/electron start",
+        "test:windows": "node desktop/electron/test/run-all.mjs",
+        "test:windows:unit": "node desktop/electron/test/run-all.mjs --unit"
     },
     "keywords": [
         "python",


### PR DESCRIPTION
Phase 0 of `docs/WINDOWS_STORE_PROPOSAL.md`: determine whether SciREPL Free can run as a secure, standalone Electron application on Windows with minimal impact on Android/Capacitor.

**Outcome: no blockers found. Recommend proceeding to Phase 1.**

Full write-up: `docs/WINDOWS_ELECTRON_SPIKE.md`

## Verification status

**The full automated suite passes on Windows** (`windows-latest` / Windows Server 2025): all 8 suites, **199 assertions, 0 failures**, including the Playwright Chromium baseline — so the kernel-parity result is measured on Windows, not inherited from Linux. The same suite passes on Linux (WSL2, Electron 43.3.0 / Chromium 150).

**Not covered:** anything a human has to look at. Display scaling, native Save/Open dialogs, PDF export, external-link handover, accessibility (high contrast, keyboard-only, Narrator/NVDA), sleep/resume, non-ASCII profile paths, second-instance window focus, arm64 — plus re-measuring startup/size/memory on real hardware, since a CI VM is not a fair sample. All enumerated in §9. Nothing in the report claims an unexecuted check passed.

## What's added

A thin shell under `desktop/electron/` (5 source files, ~126 kB) that loads the **unmodified** prepared `www/` tree.

```
www/, kernels, WASM, workbooks, formats, persistence   <- shared, untouched
android/, capacitor.config.json                        <- Android only, untouched
desktop/electron/                                      <- Windows only, new
```

Electron code never enters the Android project, Capacitor code never enters the shell, and shared application code imports neither.

## Origin decision

Serves the app from a custom standard scheme, `app://scirepl`, registered `secure` with fetch/stream/service-worker support.

`file://` was rejected on measured grounds — it gives an **opaque** origin, which breaks IndexedDB persistence, service-worker registration, `fetch()` of relative URLs, and `WebAssembly.instantiateStreaming` (no `Content-Type`). All four verified working under `app://`.

## Security

The driving finding: SciREPL's JavaScript kernel runs notebook cells with `new AsyncFunction(code)` **in the main renderer realm** (`www/js/kernels/javascript.js:70-71`). There is no realm boundary between SciREPL's UI code and user notebook code, so anything reachable from `window` is reachable by a notebook cell.

The shell therefore **withholds capability rather than filtering it**:

- `nodeIntegration: false`, `contextIsolation: true`, `sandbox: true`, `webviewTag: false`, no remote module
- preload surface is **exactly two nullary read-only calls** (`getAppInfo`, `getDistributionInfo`) — no `invoke`, no fs, no shell
- external links handled in the **main process** via `setWindowOpenHandler` (`https:`/`mailto:` only)
- restrictive CSP applied by the protocol handler, so `www/index.html` is unchanged and the PWA is unaffected

Regression tests are written from the attacker's position — executed **through the real JavaScript kernel**, as a notebook cell would be. `require`/`process`/`Buffer`/`__dirname` all `ReferenceError`; `new Function('return process')()`, `top.require`, `parent.require` all blocked; navigation and `window.open` off-origin both refused.

No entitlement, Store or commerce code is implemented. `getDistributionInfo()` returns `store: null`; the `StoreContext.GetAppLicenseAsync()` seam is a comment only, and `artifact-boundary.test.mjs` fails the build if it is ever implemented.

## Results — 199 assertions, 0 failures (Linux **and** Windows CI)

| Suite | Result |
| --- | --- |
| `policy-unit` | 52 passed |
| `shell-launch` | 18 passed |
| `security` | 34 passed |
| `artifact-boundary` | 14 passed |
| `download` | 9 passed |
| `persistence` | 9 passed |
| `kernels` | 46 passed, 2 known-gap skips |
| `offline` | 17 passed |

**All 8 Free-profile kernels run at parity with a Chromium baseline** — JavaScript, Bash/Brush, TypR, Lua/Fengari, ClojureScript/Scittle, SWI-Prolog, Python/Pyodide, R/webR. The *same probe module* drives both runners, so a difference would be a real platform difference rather than two divergent suites.

Also verified: notebook + SharedVFS state survives a real process restart; cross-kernel SharedVFS reaches the Python kernel; exports reach disk intact; with the network cut, bundled kernels still run and CDN kernels fail cleanly without wedging the app.

TypR's empty `cat()` output reproduces **identically** in the browser baseline and the repo's own `test_typr_kernel.mjs` already tolerates it — reported as a pre-existing gap, not silently relaxed.

## Three findings that shape Phase 1

**1. Renderer realm boundary** (above) — gates any safe `saveFile`.

**2. The service worker cache is inert under `app://`** — `Failed to execute 'addAll' on 'Cache': Request scheme 'app' is unsupported`. The Cache API only accepts http/https. The app shell is unaffected (assets come from the protocol handler off disk, which is why offline still passes), but **CDN kernels cannot be cached for offline use**, and the "cached" branch of the download-consent check never hits. Not worked around: the right fix is for a packaged desktop app to *bundle* its runtimes, which is what the existing `pro` profile already does for R.

**3. The Ko-fi widget is blocked** — `www/index.html:407` loads a third-party script from `storage.ko-fi.com`, deliberately absent from the CSP allowlist. It degrades silently (already guarded by `if (typeof kofiwidget2 !== 'undefined')`). The CSP is **not** weakened: that would grant a third-party host arbitrary execution in the realm that runs user notebooks. The exclusion is pinned by tests (`KOFI_EXCLUSION`, plus a captured live `securitypolicyviolation`) so it stays a decision. Proper fix is a shared plain-link change, deferred because it touches `www/`.

## Two bugs the tests caught

**`isAppUrl()` compared `url.origin`** — which is `"null"` in the main process, because `registerSchemesAsPrivileged` teaches *Chromium* the scheme but the main process parses URLs with **Node's** implementation. It would have blocked the app from navigating within itself. Now compares scheme + host, with a positive in-app-navigation assertion.

**A losing single-instance launch hung** — `main.js` called `app.quit()` on a failed lock, then carried on to register `whenReady` anyway; a process that is quitting but still waiting for `ready` never becomes ready and never exits. Fixed; a second instance now exits in ~0.5 s.

## Android / PWA impact

**No shared runtime file was modified.** The complete diff outside `desktop/`:

- `package.json` — **+4 additive scripts only**
- `.gitignore` — +4 ignore rules for Electron output
- `docs/WINDOWS_ELECTRON_SPIKE.md`, `.github/workflows/windows-electron-spike.yml` — new

Untouched: `www/**`, `android/**`, `capacitor.config.json`, `build-profiles.json`, `scripts/**`, `server.js`, `sw.js`, root `package-lock.json`, every existing script, and both existing workflows.

Existing browser tests re-run unchanged: `test_js_kernel` 13/13, `test_lua_kernel`, `test_sharedvfs_sync`, `test_notebook_vfs` — all pass. The Android build was **not** executed (no SDK here); the argument it is unaffected is structural, not empirical.

Electron is pinned exactly (`43.3.0`) in its **own** `desktop/electron/package.json`, so a root `npm install` — what the Android build and existing CI do — does not download a ~220 MB Chromium runtime.

## CI

- **`shell-policy`** (ubuntu) — 52 unit assertions, no display, no Electron download. Verified by reproducing the job's exact environment (no Electron binary, no Playwright) → 52/52.
- **`windows-shell`** (windows-latest) — the full suite plus the Chromium baseline. Runs `npx playwright install chromium` explicitly (`npm install` provisions the Playwright package but not browser binaries) and sets `SCIREPL_COMPARE_BASELINE=1`, which is what makes that download load-bearing.

A `smoke.mjs` step runs first and prints the main process's own stdout/stderr, because Playwright reports any launch failure as a bare timeout. It is what made the two Windows-only harness bugs diagnosable and what surfaced the service-worker finding.

Note: `windows-shell` reaches CDN hosts for the baseline comparison. If that proves flaky, drop it back to `workflow_dispatch` rather than letting a red job become noise.

## Measurements (Linux — re-measure on real Windows hardware)

| Item | Value |
| --- | --- |
| Prepared `www/` (Free `full`) | 108.3 MB |
| Electron runtime, unpacked | 327.4 MB |
| Launch -> app ready | 1398 ms |
| Memory idle / with Pyodide | 668 MB / 936 MB (inflated by shared-page counting and WSLg software rendering — indicative only) |

## Proposed Phase 1

Phase 0 needed **zero** changes to `www/`, because every existing `window.Capacitor` call site already has a working browser fallback that Electron uses unchanged (all six enumerated in the report). So Phase 1 should **not** be a broad "abstract Capacitor away" refactor — that would be motion, not progress.

1. **Decide the renderer realm boundary first** (Worker/sandboxed iframe, or OS-dialog confirmation for every native op). Benefits Android and the PWA too.
2. Platform interface for **exactly two** operations — `saveFile`, `openFile`.
3. Add a `will-download` handler for proper Save As.
4. Migrate the `PdfGenerator` call site last, after Windows print verification.
5. Replace the Ko-fi widget with a plain external link (shared change).
6. Define a Windows build profile that **bundles** Lua (and R for Pro) rather than relying on the now-inert service worker cache.

Deferred as unjustified by any Phase 0 observation: `shareFile`, exposed `openExternal`, MSIX, Store licensing, and all Pro work.

## Scope discipline

No Pro material, no Pro PWA, no Store/entitlement/commerce code, no packaging, no release. No generated installers, runtimes, `node_modules` or build output are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViSPjSKEFZyKAHty5DfWFT