### PR TITLE
Phase 0.5: portable Windows preview, one-command dev launch, and offline runtime cache

### DIFF
--- a/.github/workflows/windows-portable-preview.yml
+++ b/.github/workflows/windows-portable-preview.yml
@@ -27,6 +27,10 @@ on:
         description: 'Verify the packaged app before uploading (recommended)'
         type: boolean
         default: true
+      linux:
+        description: 'Also build a Linux x64 portable preview'
+        type: boolean
+        default: false
 
 concurrency:
   group: windows-portable-preview-${{ github.ref }}
@@ -66,6 +70,17 @@ jobs:
       - name: Build the portable preview
         run: npm run package:windows
 
+      # Optional second asset. @electron/packager cross-builds, so the Linux
+      # preview is produced on the same Windows runner from the same prepared
+      # tree — one build, two platforms, no drift between them.
+      #
+      # It is unverified here: the packaged suite below runs the Windows binary,
+      # which is the only one this runner can execute. Treat the Linux artifact
+      # as built-not-tested until it is run on Linux.
+      - name: Build the Linux portable preview
+        if: ${{ inputs.linux }}
+        run: node desktop/electron/packaging/build-portable.mjs --platform linux --arch x64
+
       # Prove the packaged application actually works before handing it to
       # anyone: it must load app://scirepl/index.html from its own bundled
       # resources, keep notebook code away from Node and unrestricted Electron
@@ -88,6 +103,16 @@ jobs:
           retention-days: 14
           # Already ~450 MB of mostly-incompressible binaries; recompressing
           # buys little and costs minutes.
+          compression-level: 1
+
+      - name: Upload the Linux preview
+        if: ${{ inputs.linux }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: SciREPL-linux-x64-preview-${{ github.sha }}
+          path: desktop/electron/out/SciREPL-linux-x64/
+          if-no-files-found: error
+          retention-days: 14
           compression-level: 1
 
       - name: Upload test results
@@ -118,6 +143,13 @@ jobs:
             echo "This is a **preview build**, not a release: Free edition only, no installer,"
             echo "no auto-update, and not a Microsoft Store package."
             echo
+            if [ "${{ inputs.linux }}" = "true" ]; then
+              echo "A **Linux x64** preview is also attached. It is cross-built here and"
+              echo "**not executed** by this job — the runner can only run the Windows binary."
+              echo "On Linux: extract, then run \`./SciREPL\`. Note it installs no .desktop"
+              echo "file, so some desktop environments show a generic icon and label."
+              echo
+            fi
             echo "Kernels bundled offline: Bash/Brush, ClojureScript/Scittle, SWI-Prolog, Python/Pyodide."
             echo "Lua and R load from a CDN. Lua keeps working offline after one online use;"
             echo "R (~50 MB) needs the network each session. The download prompt appears every"

--- a/.github/workflows/windows-portable-preview.yml
+++ b/.github/workflows/windows-portable-preview.yml
@@ -1,0 +1,125 @@
+# Phase 0.5 — unsigned portable Windows preview.
+#
+# Builds a downloadable ZIP containing a directly launchable SciREPL.exe, so the
+# Free application can be evaluated on Windows without installing Node, Git or a
+# web server. Extract, run, done.
+#
+# This is a PREVIEW, not a release:
+#   - unsigned, so SmartScreen warns on first run (see desktop/electron/README.md);
+#   - Free edition only — no Pro content, no Store or entitlement code;
+#   - no installer, no auto-update, no MSIX, no Store submission;
+#   - published only as a workflow artifact, never as a public release.
+#
+# `workflow_dispatch` only, deliberately. The job downloads ~220 MB of Electron
+# plus ~104 MB of kernel runtimes and produces a ~450 MB artifact; running it on
+# every push would be a poor trade for something a human asks for when they want
+# to look at the app. Correctness of the shell is already gated by
+# windows-electron-spike.yml on pull requests.
+#
+# Additive: nothing here touches the Android or PWA pipelines.
+
+name: Windows portable preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-tests:
+        description: 'Verify the packaged app before uploading (recommended)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: windows-portable-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    name: Build and verify the portable preview
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install root dependencies
+        run: npm install
+
+      # The Free profile. build-portable.mjs refuses to package the `pro`
+      # profile or a tree containing the offline R runtime, so this is enforced
+      # rather than assumed.
+      - name: Configure the Free build profile
+        run: npm run configure
+
+      - name: Fetch the Free bundled runtimes
+        run: npm run fetch:bundles
+
+      - name: Install Electron (isolated, pinned)
+        run: npm run windows:install
+
+      - name: Build the portable preview
+        run: npm run package:windows
+
+      # Prove the packaged application actually works before handing it to
+      # anyone: it must load app://scirepl/index.html from its own bundled
+      # resources, keep notebook code away from Node and unrestricted Electron
+      # APIs, run the bundled kernels, survive a restart with its IndexedDB and
+      # SharedVFS intact, and contain no Pro material. Reuses the same probes as
+      # the development suite — see desktop/electron/test/probes/.
+      - name: Verify the packaged application
+        if: ${{ inputs.run-tests }}
+        run: node desktop/electron/test/run-all.mjs packaged
+
+      # Uploading the *contents* of the packaged directory means the artifact
+      # GitHub produces is itself the distributable ZIP: download, extract,
+      # double-click SciREPL.exe. No nested archive to unwrap twice.
+      - name: Upload the preview ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: SciREPL-windows-x64-preview-${{ github.sha }}
+          path: desktop/electron/out/SciREPL-win32-x64/
+          if-no-files-found: error
+          retention-days: 14
+          # Already ~450 MB of mostly-incompressible binaries; recompressing
+          # buys little and costs minutes.
+          compression-level: 1
+
+      - name: Upload test results
+        if: ${{ always() && inputs.run-tests }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-test-results-${{ github.sha }}
+          path: desktop/electron/test/results/
+          if-no-files-found: warn
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## SciREPL — unsigned portable Windows preview"
+            echo
+            echo "**Commit:** \`${GITHUB_SHA}\`"
+            echo
+            echo "1. Download **SciREPL-windows-x64-preview-${GITHUB_SHA}** from the artifacts below."
+            echo "2. Extract the ZIP somewhere local (not a network path)."
+            echo "3. Run **SciREPL.exe**."
+            echo
+            echo "The build is **unsigned**, so Windows SmartScreen will show"
+            echo "\"Windows protected your PC\" on first run. Choose **More info -> Run anyway**."
+            echo "That warning is expected for an unsigned preview and is not a sign of a problem."
+            echo
+            echo "This is a **preview build**, not a release: Free edition only, no installer,"
+            echo "no auto-update, and not a Microsoft Store package."
+            echo
+            echo "Kernels bundled offline: Bash/Brush, ClojureScript/Scittle, SWI-Prolog, Python/Pyodide."
+            echo "Lua and R load from a CDN and need a network connection **every session** —"
+            echo "the service worker cache does not work under the \`app://\` origin, so they"
+            echo "are not cached for offline use. See docs/WINDOWS_ELECTRON_SPIKE.md."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/windows-portable-preview.yml
+++ b/.github/workflows/windows-portable-preview.yml
@@ -151,7 +151,17 @@ jobs:
               echo
             fi
             echo "Kernels bundled offline: Bash/Brush, ClojureScript/Scittle, SWI-Prolog, Python/Pyodide."
-            echo "Lua and R load from a CDN. Lua keeps working offline after one online use;"
-            echo "R (~50 MB) needs the network each session. The download prompt appears every"
-            echo "session either way. See docs/WINDOWS_ELECTRON_SPIKE.md section 5."
+            echo
+            echo "Lua and R are fetched from their CDNs the first time you use them, then kept"
+            echo "in SciREPL's own runtime cache under %APPDATA%\\SciREPL-Free-Electron. After that"
+            echo "first successful download they run offline, and the cache survives restarts."
+            echo "Measured: R goes from a 90s timeout offline to running in about a second."
+            echo
+            echo "The first download asks for confirmation. To stop being asked, turn on"
+            echo "Settings -> Runtime Downloads -> \"Auto-download runtimes (skip confirmation)\";"
+            echo "the choice is saved and behaves the same as on Android."
+            echo
+            echo "R package *listings* from repo.r-wasm.org are deliberately not cached, since"
+            echo "that repository is mutable — installing new R packages still needs a network"
+            echo "connection. See docs/WINDOWS_ELECTRON_SPIKE.md section 5."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/windows-portable-preview.yml
+++ b/.github/workflows/windows-portable-preview.yml
@@ -119,7 +119,7 @@ jobs:
             echo "no auto-update, and not a Microsoft Store package."
             echo
             echo "Kernels bundled offline: Bash/Brush, ClojureScript/Scittle, SWI-Prolog, Python/Pyodide."
-            echo "Lua and R load from a CDN and need a network connection **every session** —"
-            echo "the service worker cache does not work under the \`app://\` origin, so they"
-            echo "are not cached for offline use. See docs/WINDOWS_ELECTRON_SPIKE.md."
+            echo "Lua and R load from a CDN. Lua keeps working offline after one online use;"
+            echo "R (~50 MB) needs the network each session. The download prompt appears every"
+            echo "session either way. See docs/WINDOWS_ELECTRON_SPIKE.md section 5."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -1,4 +1,4 @@
-# SciREPL — Windows/Electron shell (Phase 0 feasibility spike)
+# SciREPL — Windows/Electron shell
 
 A thin Electron shell around the **existing** prepared `www/` application. It is
 the Windows-specific half of the split described in
@@ -15,21 +15,33 @@ Capacitor. The shared application code imports neither framework — the shell
 loads `www/` exactly as the PWA does, and the app takes its existing browser
 code paths because `window.Capacitor` is absent.
 
-**Status: feasibility spike, Free edition only.** There is no packaging, no
-Microsoft Store integration and no entitlement logic here, deliberately. See
-[`docs/WINDOWS_ELECTRON_SPIKE.md`](../../docs/WINDOWS_ELECTRON_SPIKE.md) for
-measured results and the recommendation.
+**Status: Free edition only.** Phase 0 established feasibility
+([`docs/WINDOWS_ELECTRON_SPIKE.md`](../../docs/WINDOWS_ELECTRON_SPIKE.md));
+Phase 0.5 added a one-command developer launch and an unsigned **portable
+preview** so the app can be evaluated on Windows without a toolchain.
+
+There is still no Microsoft Store integration, no MSIX, no entitlement logic and
+no signing — deliberately. The preview is not a release. To run it, see
+[`docs/WINDOWS_PREVIEW.md`](../../docs/WINDOWS_PREVIEW.md).
 
 ## Commands
 
 Run from the repository root:
 
 ```bash
-npm run windows:install    # install Electron (isolated; see "Dependency isolation")
-npm run dev:windows        # configure + fetch runtimes + launch the shell
+npm run dev:windows        # one command: check, configure, fetch, install, launch
+npm run setup:windows      # the same, without launching
+npm run package:windows    # build the unsigned portable preview
 npm run test:windows       # all shell tests (needs Electron + a display)
 npm run test:windows:unit  # policy unit tests only (no display, no Electron binary)
+npm run windows:install    # just the Electron install step
 ```
+
+`dev:windows` is the entry point for a fresh checkout. It verifies Node (>= 22),
+reports the platform, configures the Free profile, fetches the bundled runtimes,
+installs the isolated Electron dependencies, provisions the Electron binary, and
+launches — skipping whatever is already done, so it is also the everyday "start
+the app" command. It installs nothing system-wide and needs no elevation.
 
 Individual suites:
 
@@ -144,6 +156,9 @@ drifting. The proper fix is a shared change — replace the widget with a plain
 | `security.js` | navigation / window-open / permission policy |
 | `preload.js` | the entire renderer-visible surface (two read-only calls) |
 | `ipc.js` | the canonical IPC allowlist, owned by the main process |
+| `paths.js` | resolves `www/` and build metadata in **both** layouts (development and packaged) |
+| `scripts/dev-windows.mjs` | the one-command setup + launch |
+| `packaging/build-portable.mjs` | builds the unsigned portable preview |
 | `test/` | see below |
 
 ## Tests
@@ -158,6 +173,14 @@ drifting. The proper fix is a shared change — replace the widget with a plain
 | `persistence.test.mjs` | yes | IndexedDB / SharedVFS / localStorage across a real restart |
 | `kernels.test.mjs` | yes | one execution per kernel + SharedVFS; optional browser A/B |
 | `offline.test.mjs` | yes | bundled kernels with the network cut; CDN kernels fail cleanly |
+| `packaged.test.mjs` | yes, **and a built package** | the packaged app: own `www/`, security boundary, kernels, restart persistence, no Pro material |
+
+`packaged.test.mjs` is opt-in — it needs an artifact most runs do not have:
+
+```bash
+npm run package:windows
+node desktop/electron/test/run-all.mjs packaged   # or: run-all.mjs --packaged
+```
 
 Two tools sit alongside the suites and are run explicitly, not by `run-all`:
 
@@ -173,8 +196,15 @@ On failure it retries once with `--disable-gpu --no-sandbox
 --disable-software-rasterizer`, so one run distinguishes a broken shell from a
 host that needs GPU flags. Reach for it first whenever the shell will not start.
 
-`test/probes/kernels.mjs` holds the kernel assertions and is driven by **both**
-the Electron runner and the Chromium baseline runner, so a difference in results
-is a real platform difference rather than two divergent test suites. Export
-*correctness* is not re-tested here — the existing browser tests in the
+The probes under `test/probes/` are the reason these suites do not drift apart:
+
+- `probes/kernels.mjs` is driven by the Electron runner, the Chromium baseline
+  runner **and** the packaged suite, so a difference in results is a real
+  platform difference rather than two divergent test suites.
+- `probes/security.mjs` holds the renderer/native boundary checks and is applied
+  identically to the development shell and the packaged build. That is
+  deliberate: a packaged app quietly regaining Node access while a separate copy
+  of the assertions kept passing is exactly the failure worth designing out.
+
+Export *correctness* is not re-tested here — the existing browser tests in the
 repository root already cover it and that logic is platform-independent.

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -69,6 +69,8 @@ Android/PWA workflows are untouched.
 | `SCIREPL_WWW` | serve a different prepared `www/` tree |
 | `SCIREPL_USER_DATA` | use a specific profile directory (the persistence tests rely on this) |
 | `SCIREPL_COMPARE_BASELINE=1` | also run the kernel probes in plain Chromium and compare |
+| `SCIREPL_RUNTIME_CACHE=0` | disable the on-disk runtime cache and fall back to Chromium's own heuristic HTTP cache |
+| `SCIREPL_RUNTIME_CACHE_DEBUG=1` | log every cache decision to `userData/runtime-cache-debug.log` |
 | `SCIREPL_ELECTRON_NO_SANDBOX=1` | launch with `--no-sandbox` for containers without a usable setuid helper. The security suite records this and refuses to claim the sandbox was verified. |
 
 ## Dependency isolation
@@ -156,6 +158,7 @@ drifting. The proper fix is a shared change — replace the widget with a plain
 | `security.js` | navigation / window-open / permission policy |
 | `preload.js` | the entire renderer-visible surface (two read-only calls) |
 | `ipc.js` | the canonical IPC allowlist, owned by the main process |
+| `runtime-cache.js` | persistent on-disk cache for CDN runtimes, in `userData` — replaces the service worker's `CDN_CACHE`, which cannot work under `app://` |
 | `paths.js` | resolves `www/` and build metadata in **both** layouts (development and packaged) |
 | `scripts/dev-windows.mjs` | the one-command setup + launch |
 | `packaging/build-portable.mjs` | builds the unsigned portable preview |
@@ -174,6 +177,7 @@ drifting. The proper fix is a shared change — replace the widget with a plain
 | `kernels.test.mjs` | yes | one execution per kernel + SharedVFS; optional browser A/B |
 | `offline.test.mjs` | yes | bundled kernels with the network cut; CDN kernels fail cleanly |
 | `packaged.test.mjs` | yes, **and a built package** | the packaged app: own `www/`, security boundary, kernels, restart persistence, no Pro material |
+| `runtime-cache.test.mjs` | yes, **and network** | Lua and R still run offline after a restart; a cold profile still fails |
 
 `packaged.test.mjs` is opt-in — it needs an artifact most runs do not have:
 

--- a/desktop/electron/ipc.js
+++ b/desktop/electron/ipc.js
@@ -32,6 +32,7 @@ function assertNullary(channel, args) {
 function registerIpcHandlers(options = {}) {
   const appVersion = options.appVersion || '0.0.0';
   const profile = options.profile || 'unknown';
+  const buildInfo = options.buildInfo || null;
 
   ipcMain.handle(CHANNELS.APP_INFO, (_event, ...args) => {
     assertNullary(CHANNELS.APP_INFO, args);
@@ -60,6 +61,12 @@ function registerIpcHandlers(options = {}) {
       packaged: app.isPackaged,
       profile,
       store: null,
+      // Build provenance for a packaged preview, so a tester can say exactly
+      // which build they are looking at. Null in development. These are inert
+      // facts — no behaviour keys off them.
+      commit: (buildInfo && buildInfo.commit) || null,
+      builtAt: (buildInfo && buildInfo.builtAt) || null,
+      channel: (buildInfo && buildInfo.channel) || 'development',
     };
   });
 }

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -100,6 +100,38 @@ function readProfile() {
   return 'unknown';
 }
 
+/**
+ * Identity. Without these the app registers under the package directory's name
+ * — `scirepl-desktop-electron` — which is what a desktop environment shows in
+ * the task bar. Under WSLg that also produced a second, iconless entry
+ * (`appIcon: (nil)` in weston.log), which Windows renders as a generic penguin.
+ *
+ * `setName` must run before `app.whenReady()`, and before userData is derived
+ * from it by anything else.
+ */
+app.setName('SciREPL');
+// Groups windows correctly on the Windows task bar and keeps the identity
+// stable across builds.
+if (process.platform === 'win32') app.setAppUserModelId('com.unifyweaver.scirepl');
+
+// NOTE for Linux packaging, measured rather than assumed: neither
+// `app.setName()` above nor Chromium's `--class` switch changes how a desktop
+// environment labels the window. WSLg kept reporting
+// `appId: scirepl-desktop-electron` with `appIcon: (nil)` after both, because
+// the identity comes from the `name` in the package.json inside app.asar, and
+// the icon is resolved by matching that identity against an *installed*
+// .desktop file — which a portable directory does not have. Fixing it properly
+// means shipping a .desktop file and icon, i.e. a real Linux package rather
+// than a portable folder. Recorded in docs/WINDOWS_ELECTRON_SPIKE.md.
+
+/**
+ * The window/task-bar icon. Shared with the PWA rather than duplicated, so the
+ * desktop build cannot drift from the icon users already associate with SciREPL.
+ * Windows takes its executable icon from the packager instead; this covers
+ * Linux, where the icon comes from the running window.
+ */
+const APP_ICON = path.join(WWW_ROOT, 'icons', 'icon-512.png');
+
 /** Scheme registration must happen before the app is ready. */
 registerScheme();
 
@@ -129,6 +161,7 @@ function createWindow() {
     show: false,
     backgroundColor: '#0d1117', // matches the app's theme-color, avoids white flash
     title: 'SciREPL',
+    ...(fs.existsSync(APP_ICON) ? { icon: APP_ICON } : {}),
     webPreferences: {
       // --- the security boundary ---
       nodeIntegration: false,
@@ -148,9 +181,31 @@ function createWindow() {
 
   applyWebContentsPolicy(mainWindow.webContents);
 
-  mainWindow.once('ready-to-show', () => {
+  // The window is created hidden and shown on `ready-to-show` to avoid a white
+  // flash. The risk is that `ready-to-show` never fires — a stalled load, a
+  // renderer that died during startup — leaving a window that exists, owns a
+  // taskbar entry, and can never be raised because it is hidden. Clicking the
+  // icon then appears to do nothing, which is exactly how this presented in
+  // practice with stray instances left behind by killed test runs.
+  //
+  // So showing it is a race between "looks nice" and "always reachable", and
+  // reachable wins.
+  let shown = false;
+  const showOnce = (why) => {
+    if (shown || !mainWindow || mainWindow.isDestroyed()) return;
+    shown = true;
+    clearTimeout(showFallback);
+    if (why !== 'ready-to-show') {
+      console.warn(`[scirepl] showing window via ${why} — ready-to-show did not fire`);
+    }
     mainWindow.show();
-  });
+  };
+
+  const showFallback = setTimeout(() => showOnce('timeout'), 10_000);
+  mainWindow.once('ready-to-show', () => showOnce('ready-to-show'));
+  // A load that finished but never painted still deserves a visible window.
+  mainWindow.webContents.once('did-finish-load', () => showOnce('did-finish-load'));
+  mainWindow.webContents.once('did-fail-load', () => showOnce('did-fail-load'));
 
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -207,6 +207,18 @@ function createWindow() {
   mainWindow.webContents.once('did-finish-load', () => showOnce('did-finish-load'));
   mainWindow.webContents.once('did-fail-load', () => showOnce('did-fail-load'));
 
+  // Detached DevTools is a BrowserWindow of its own. If the user closes the main
+  // window while it is open, that window survives, `window-all-closed` never
+  // fires, and the application stays running with no visible window — it has to
+  // be killed. Close DevTools along with the window that owns it.
+  //
+  // Found by the packaged suite's DevTools assertions: graceful shutdown began
+  // timing out and needing SIGKILL once anything opened DevTools.
+  mainWindow.on('close', () => {
+    const wc = mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null;
+    if (wc && wc.isDevToolsOpened()) wc.closeDevTools();
+  });
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -22,6 +22,7 @@ const {
 } = require('./protocol');
 const { applyWebContentsPolicy } = require('./security');
 const { registerIpcHandlers } = require('./ipc');
+const { installRuntimeCache } = require('./runtime-cache');
 
 const { resolveWwwRoot, resolveBuildInfoPath, resolveRepoRoot } = require('./paths');
 
@@ -116,6 +117,7 @@ if (!gotLock) {
 }
 
 let mainWindow = null;
+let runtimeCache = null;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -207,6 +209,22 @@ app.whenReady().then(() => {
   }
 
   registerProtocolHandler(WWW_ROOT);
+
+  // Persistent cache for CDN runtimes, in the app's own data directory.
+  // Replaces the service worker's CDN_CACHE, which cannot function under the
+  // app:// origin (see runtime-cache.js). Set SCIREPL_RUNTIME_CACHE=0 to
+  // disable and fall back to Chromium's own heuristic HTTP cache.
+  if (process.env.SCIREPL_RUNTIME_CACHE !== '0') {
+    try {
+      runtimeCache = installRuntimeCache(session.defaultSession, {
+        cacheDir: path.join(app.getPath('userData'), 'runtime-cache'),
+      });
+    } catch (e) {
+      // A shell that starts without its cache is fine; one that fails to start
+      // because of it is not.
+      console.error('[scirepl] runtime cache unavailable:', e && e.message);
+    }
+  }
   registerIpcHandlers({
     appVersion: readAppVersion(),
     profile: readProfile(),

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -23,9 +23,22 @@ const {
 const { applyWebContentsPolicy } = require('./security');
 const { registerIpcHandlers } = require('./ipc');
 
-/** Repository root, two levels up from desktop/electron/. */
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
-const WWW_ROOT = process.env.SCIREPL_WWW || path.join(REPO_ROOT, 'www');
+const { resolveWwwRoot, resolveBuildInfoPath, resolveRepoRoot } = require('./paths');
+
+/**
+ * Content locations. These differ between the development checkout and a
+ * packaged build, so they come from paths.js rather than being derived inline
+ * from `__dirname` — inside a packaged app `__dirname` is within
+ * resources/app.asar and has no repository above it.
+ */
+const LAYOUT = {
+  isPackaged: app.isPackaged,
+  resourcesPath: process.resourcesPath,
+  moduleDir: __dirname,
+  env: process.env,
+};
+const WWW_ROOT = resolveWwwRoot(LAYOUT);
+const REPO_ROOT = resolveRepoRoot(LAYOUT); // null when packaged
 
 /**
  * A distinct userData directory. The shell must not collide with any other
@@ -38,7 +51,26 @@ if (process.env.SCIREPL_USER_DATA) {
   app.setPath('userData', path.join(app.getPath('appData'), 'SciREPL-Free-Electron'));
 }
 
+/**
+ * Build metadata written by desktop/electron/packaging/build-portable.mjs.
+ * Present only in packaged builds; absent in development, which is not an error.
+ */
+function readBuildInfo() {
+  try {
+    return JSON.parse(fs.readFileSync(resolveBuildInfoPath(LAYOUT), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function readAppVersion() {
+  // Packaged: the version baked into the app by the packager, which is the
+  // repository's version at build time. Reading package.json from a repository
+  // that no longer exists next to the binary would always fail here.
+  if (app.isPackaged) {
+    const info = readBuildInfo();
+    return (info && info.appVersion) || app.getVersion();
+  }
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
     return pkg.version || '0.0.0';
@@ -48,6 +80,12 @@ function readAppVersion() {
 }
 
 function readProfile() {
+  // In a packaged build the profile was fixed when the tree was configured, and
+  // the packager recorded it. Prefer that; fall back to reading the generated
+  // config, which works in both layouts.
+  const info = readBuildInfo();
+  if (info && info.profile) return info.profile;
+
   // scripts/configure-build.mjs writes www/js/kernel_config.js from
   // build-profiles.json. Report which profile the tree was configured with so
   // the shell never has to guess which kernels should be present.
@@ -169,7 +207,11 @@ app.whenReady().then(() => {
   }
 
   registerProtocolHandler(WWW_ROOT);
-  registerIpcHandlers({ appVersion: readAppVersion(), profile: readProfile() });
+  registerIpcHandlers({
+    appVersion: readAppVersion(),
+    profile: readProfile(),
+    buildInfo: readBuildInfo(),
+  });
 
   createWindow();
 

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -23,6 +23,7 @@ const {
 const { applyWebContentsPolicy } = require('./security');
 const { registerIpcHandlers } = require('./ipc');
 const { installRuntimeCache } = require('./runtime-cache');
+const { installApplicationMenu } = require('./menu');
 
 const { resolveWwwRoot, resolveBuildInfoPath, resolveRepoRoot } = require('./paths');
 
@@ -232,6 +233,17 @@ app.whenReady().then(() => {
   });
 
   createWindow();
+
+  // Replaces Electron's default menu. It carries the only surface from which
+  // the runtime cache can be inspected or cleared: the application's own
+  // Memory & Storage panel works through the Cache API, which is always empty
+  // under app://, so it neither sees nor clears this cache. See menu.js.
+  installApplicationMenu({
+    getCache: () => runtimeCache,
+    getBuildInfo: readBuildInfo,
+    getWindow: () => mainWindow,
+    appVersion: readAppVersion(),
+  });
 
   if (process.env.SCIREPL_SMOKE_EXIT === '1') runSmokeCheck(mainWindow);
 

--- a/desktop/electron/menu.js
+++ b/desktop/electron/menu.js
@@ -1,0 +1,208 @@
+/**
+ * menu.js — the application menu.
+ *
+ * Two reasons this exists rather than leaving Electron's default menu in place.
+ *
+ * 1. The default menu is Electron's, not SciREPL's. Its Help item links to
+ *    electronjs.org, which is the wrong thing to offer someone evaluating
+ *    SciREPL.
+ *
+ * 2. More importantly, the shell keeps a runtime cache in its data directory
+ *    (runtime-cache.js) that the application's own **Memory & Storage** panel
+ *    cannot see or clear. That panel works through the Cache API, which is
+ *    always empty under `app://`:
+ *
+ *      - "Clear Cache" deletes two empty caches, reports success, and leaves
+ *        the downloaded runtimes on disk;
+ *      - the per-runtime "Clear Cache" button never appears, because it is
+ *        shown only when the CDN cache has matching entries;
+ *      - the storage figure comes from `navigator.storage.estimate()`, which
+ *        does not count plain files in userData.
+ *
+ *    Shipping a cache with no way to inspect or clear it is not acceptable, and
+ *    the panel lives in `www/`, which is shared with the PWA and Android and is
+ *    not modified by the shell. So the shell provides the management surface it
+ *    owns. Teaching the in-app panel about it needs a shared-code change and is
+ *    recorded as Phase 1 work in docs/WINDOWS_ELECTRON_SPIKE.md.
+ *
+ * Everything here runs in the main process and is driven by the user through
+ * the menu bar. None of it is reachable from the renderer, so the boundary in
+ * security.js is unchanged.
+ */
+
+const { Menu, dialog, shell, app } = require('electron');
+
+const REPO_URL = 'https://github.com/s243a/SciREPL';
+
+function formatBytes(bytes) {
+  if (!bytes) return '0 B';
+  const units = ['B', 'kB', 'MB', 'GB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1000)), units.length - 1);
+  return `${(bytes / Math.pow(1000, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+/**
+ * @param {object} deps
+ * @param {() => import('./runtime-cache').RuntimeCache|null} deps.getCache
+ * @param {() => object|null} deps.getBuildInfo
+ * @param {() => Electron.BrowserWindow|null} deps.getWindow
+ * @param {string} deps.appVersion
+ */
+function buildApplicationMenu(deps) {
+  const { getCache, getBuildInfo, getWindow, appVersion } = deps;
+
+  async function showCacheInfo() {
+    const cache = getCache();
+    const win = getWindow();
+    if (!cache) {
+      await dialog.showMessageBox(win, {
+        type: 'info',
+        title: 'Downloaded runtimes',
+        message: 'The runtime cache is disabled.',
+        detail: 'SCIREPL_RUNTIME_CACHE=0 is set, so downloaded runtimes are not '
+          + 'kept in the application data directory.',
+      });
+      return;
+    }
+    const { bytes, entries } = await cache.size();
+    await dialog.showMessageBox(win, {
+      type: 'info',
+      title: 'Downloaded runtimes',
+      message: entries === 0
+        ? 'No runtimes have been downloaded yet.'
+        : `${formatBytes(bytes)} across ${entries} file${entries === 1 ? '' : 's'}.`,
+      detail: 'Language runtimes fetched from the internet (Lua, R) are kept here '
+        + 'so they keep working offline.\n\n' + cache.dir,
+    });
+  }
+
+  async function clearCache() {
+    const cache = getCache();
+    const win = getWindow();
+    if (!cache) return;
+
+    const { bytes, entries } = await cache.size();
+    if (entries === 0) {
+      await dialog.showMessageBox(win, {
+        type: 'info',
+        title: 'Clear downloaded runtimes',
+        message: 'There is nothing to clear.',
+      });
+      return;
+    }
+
+    // Destructive and not obviously reversible without a network connection,
+    // so it is confirmed rather than done on a single click.
+    const { response } = await dialog.showMessageBox(win, {
+      type: 'warning',
+      buttons: ['Cancel', 'Clear'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Clear downloaded runtimes',
+      message: `Delete ${formatBytes(bytes)} of downloaded runtimes?`,
+      detail: 'Lua and R will need to be downloaded again the next time you use '
+        + 'them, which requires an internet connection.\n\n'
+        + 'Your notebooks and files are not affected.',
+    });
+    if (response !== 1) return;
+
+    await cache.clear();
+    await dialog.showMessageBox(win, {
+      type: 'info',
+      title: 'Clear downloaded runtimes',
+      message: `Cleared ${formatBytes(bytes)}.`,
+      detail: 'Runtimes already loaded stay available until you restart.',
+    });
+  }
+
+  async function showAbout() {
+    const info = getBuildInfo();
+    const lines = [
+      `Version ${appVersion}`,
+      `Electron ${process.versions.electron} · Chromium ${process.versions.chrome}`,
+    ];
+    if (info) {
+      if (info.profile) lines.push(`Build profile: ${info.profile}`);
+      if (info.channel) lines.push(`Channel: ${info.channel}`);
+      if (info.commit) lines.push(`Commit: ${String(info.commit).slice(0, 12)}`);
+    }
+    await dialog.showMessageBox(getWindow(), {
+      type: 'info',
+      title: 'About SciREPL',
+      message: 'SciREPL',
+      detail: lines.join('\n'),
+    });
+  }
+
+  const template = [
+    {
+      label: '&File',
+      submenu: [
+        { role: 'reload' },
+        // Force Reload discards Chromium's own HTTP cache. It deliberately does
+        // NOT touch the runtime cache: reloading the interface should not throw
+        // away a 20 MB download.
+        { role: 'forceReload' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    {
+      // Essential for a REPL — without these, copy and paste have no menu
+      // accelerators on Windows.
+      label: '&Edit',
+      submenu: [
+        { role: 'undo' }, { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' }, { role: 'copy' }, { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: '&View',
+      submenu: [
+        { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+        { role: 'toggleDevTools' },
+      ],
+    },
+    {
+      label: '&Runtimes',
+      submenu: [
+        { label: 'Downloaded runtimes…', click: showCacheInfo },
+        { label: 'Clear downloaded runtimes…', click: clearCache },
+        { type: 'separator' },
+        {
+          label: 'Open application data folder',
+          click: () => {
+            // A fixed, application-owned path. No renderer input reaches this.
+            shell.openPath(app.getPath('userData'));
+          },
+        },
+      ],
+    },
+    {
+      label: '&Help',
+      submenu: [
+        { label: 'About SciREPL', click: showAbout },
+        {
+          label: 'SciREPL on GitHub',
+          // Goes through the same policy as an in-page link: https only.
+          click: () => shell.openExternal(REPO_URL),
+        },
+      ],
+    },
+  ];
+
+  return Menu.buildFromTemplate(template);
+}
+
+/** Build and install the menu. */
+function installApplicationMenu(deps) {
+  const menu = buildApplicationMenu(deps);
+  Menu.setApplicationMenu(menu);
+  return menu;
+}
+
+module.exports = { installApplicationMenu, buildApplicationMenu, formatBytes, REPO_URL };

--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scirepl-desktop-electron",
       "version": "0.0.0",
       "devDependencies": {
+        "@electron/packager": "20.2.0",
         "electron": "43.3.0"
       }
     },
@@ -17,6 +18,23 @@
       "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-4.2.1.tgz",
+      "integrity": "sha512-rGyEe7iy52zxiWuihV/h/AqQrFkx7YnUUJKW1bdufVDHCzIMP/XDrDI/NOzv/LLtzt3NduAzNa475WRmRnmswQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.2",
+        "minimatch": "^10.0.1"
+      },
+      "bin": {
+        "asar": "bin/asar.mjs"
+      },
       "engines": {
         "node": ">=22.12.0"
       }
@@ -42,6 +60,131 @@
         "undici": "^7.24.4"
       }
     },
+    "node_modules/@electron/notarize": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-3.1.1.tgz",
+      "integrity": "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-2.6.0.tgz",
+      "integrity": "sha512-XiJHXekSfeQpk11d9uWZ9PtDm4ADIWvcrSTRJocaDgA46t1okxrQ1keL8rthURJX6AP3DDFnzrouiP6Q5qoHYA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "isbinaryfile": "^4.0.8",
+        "plist": "^3.0.5",
+        "semver": "^7.7.1"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.mjs",
+        "electron-osx-sign": "bin/electron-osx-sign.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/packager": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-20.2.0.tgz",
+      "integrity": "sha512-0iJhVW34QLQB7OWu+MBU3Usq2ffc6bsSOa+Hqbh/4eqDU8XDdl7CPRqoVjNv/6i15BKKX8ZPCXaNVeXdNRG+QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/asar": "^4.0.1",
+        "@electron/get": "^5.0.0",
+        "@electron/notarize": "^3.1.0",
+        "@electron/osx-sign": "^2.2.0",
+        "@electron/universal": "^3.0.1",
+        "@electron/windows-sign": "^2.0.2",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.4.1",
+        "filenamify": "^6.0.0",
+        "galactus": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "junk": "^4.0.1",
+        "plist": "^3.1.0",
+        "resedit": "^2.0.3",
+        "semver": "^7.7.2",
+        "yargs-parser": "^22.0.0"
+      },
+      "bin": {
+        "electron-packager": "bin/electron-packager.mjs"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron/packager?sponsor=1"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-3.0.6.tgz",
+      "integrity": "sha512-MonS1kfkZdSEkLZI0pdR/TCx8ecxwRSFm7sORfwIkDI9UaIbHnk4Mgeqq+Ob9qDQRV8LZ9+hHCmimpA9BRcNxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^4.0.0",
+        "debug": "^4.3.1",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-2.0.6.tgz",
+      "integrity": "sha512-ESWgNkFsXFH06I5EB2uHv3hmZA3yF4j9GTB77W74x3b5KZNItxggNzuADw41HUy6mhnC2K+E2mT0Xgc4YKu3IQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "graceful-fs": "^4.2.11",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -50,6 +193,85 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -102,6 +324,87 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flora-colossus": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-3.0.2.tgz",
+      "integrity": "sha512-Jk78K/Tzt6saxQPGChlJw69xuFGpWyTSAS8EdU0h/FyXwD2K46yNOXmo6nRHcZ9ooekyBAzMkwmiGNt7wOC5zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-2.0.2.tgz",
+      "integrity": "sha512-HmKyTFGomdAchz4umx8MwBnrnfFmdpwiTyGA4ZOF7rya2Lmgbc9qate4yweInL+0gUBVImhaz12SBGpW3SY4Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "flora-colossus": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -109,12 +412,154 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
+      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -124,6 +569,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.3.tgz",
+      "integrity": "sha512-oTeemxwoMuxxTYxXUwjkrOPfngTQehlv0/HoYFNkB4uzsP1Un1A9nI8JQKGOFkxpqkC7qkMs0lUsGrvUlbLNUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/semver": {
@@ -137,6 +624,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sumchecker": {
@@ -169,6 +679,42 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     }
   }
 }

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -6,9 +6,11 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node test/run-all.mjs"
+    "test": "node test/run-all.mjs",
+    "package": "node packaging/build-portable.mjs"
   },
   "devDependencies": {
+    "@electron/packager": "20.2.0",
     "electron": "43.3.0"
   }
 }

--- a/desktop/electron/packaging/build-portable.mjs
+++ b/desktop/electron/packaging/build-portable.mjs
@@ -190,6 +190,12 @@ const appPaths = await packager({
     /^\/package-lock\.json$/,
   ],
   extraResource: [stagedWww, buildInfoPath],
+  // Desktop-environment icon. `icon-512.png` is the PWA's own icon, so the
+  // desktop builds show what users already recognise. @electron/packager wants
+  // a .ico for Windows and ignores a .png there, so the Windows executable
+  // keeps the default Electron icon for now — noted in the report as polish,
+  // not a blocker for an unsigned preview.
+  icon: path.join(WWW_ROOT, 'icons', 'icon-512'),
   win32metadata: {
     CompanyName: 'SciREPL',
     FileDescription: 'SciREPL — scientific REPL (Free, unsigned preview)',

--- a/desktop/electron/packaging/build-portable.mjs
+++ b/desktop/electron/packaging/build-portable.mjs
@@ -1,0 +1,253 @@
+/**
+ * build-portable.mjs — build the unsigned, portable Windows preview.
+ *
+ * Produces a directory containing a directly launchable `SciREPL.exe`, with no
+ * installer and nothing to register with the operating system. Extract and run.
+ *
+ *   node desktop/electron/packaging/build-portable.mjs
+ *   node desktop/electron/packaging/build-portable.mjs --platform win32 --arch x64
+ *
+ * This is a PREVIEW build, not a release:
+ *   - unsigned, so Windows SmartScreen will warn (see the README);
+ *   - Free edition only — no Pro content, no Store or entitlement code;
+ *   - no auto-update, no installer, no Store packaging.
+ *
+ * Layout produced (win32):
+ *
+ *   SciREPL-win32-x64/
+ *     SciREPL.exe
+ *     resources/
+ *       app.asar          ← the shell itself (main, protocol, security, preload, ipc)
+ *       www/              ← the prepared application tree, OUTSIDE the asar
+ *       build-info.json   ← version / profile / commit, read by main.js
+ *
+ * `www/` stays outside the asar deliberately: protocol.js serves it with
+ * `net.fetch(file://…)`, which reads real files and does not go through
+ * Electron's asar layer, and the kernel runtimes are ~100 MB — packing them
+ * would buy nothing and slow startup.
+ */
+
+import { packager } from '@electron/packager';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, mkdtempSync, rmSync, cpSync, statSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ELECTRON_DIR = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const REPO_ROOT = path.resolve(ELECTRON_DIR, '..', '..');
+const WWW_ROOT = path.join(REPO_ROOT, 'www');
+const OUT_DIR = path.join(ELECTRON_DIR, 'out');
+
+/* ------------------------------ arguments ------------------------------ */
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const platform = arg('platform', 'win32');
+const arch = arg('arch', 'x64');
+
+/* ------------------------------ preflight ------------------------------ */
+
+function fail(message) {
+  console.error(`\n[build-portable] ${message}\n`);
+  process.exit(1);
+}
+
+if (!existsSync(WWW_ROOT)) {
+  fail(`No prepared application tree at ${WWW_ROOT}.\nRun:  npm run configure && npm run fetch:bundles`);
+}
+
+const kernelConfig = path.join(WWW_ROOT, 'js', 'kernel_config.js');
+if (!existsSync(kernelConfig)) {
+  fail(`www/js/kernel_config.js is missing — the tree has not been configured.\nRun:  npm run configure`);
+}
+
+const profileMatch = readFileSync(kernelConfig, 'utf8')
+  .match(/["']?profile["']?\s*:\s*["']([^"']+)["']/);
+const profile = profileMatch ? profileMatch[1] : 'unknown';
+
+// Free-only boundary, enforced at build time rather than trusted. `pro` is the
+// profile that bundles the R runtime offline; a preview must never ship it.
+if (profile === 'pro') {
+  fail(`Refusing to package the 'pro' profile. This preview is Free-only.\nRun:  npm run configure   (which selects the default Free profile)`);
+}
+if (existsSync(path.join(WWW_ROOT, 'vendor', 'webr'))) {
+  fail(`www/vendor/webr/ is present — that is the Pro offline R runtime.\nThis preview is Free-only. Remove it and re-run npm run fetch:bundles.`);
+}
+
+// A tree configured but never populated produces an app that launches and then
+// fails to load every kernel. Catch it here rather than in the tester's hands.
+const bundled = ['pyodide', 'swipl', 'scittle'].filter(
+  (d) => !existsSync(path.join(WWW_ROOT, 'vendor', d))
+);
+if (bundled.length) {
+  fail(`Bundled runtimes missing from www/vendor: ${bundled.join(', ')}\nRun:  npm run fetch:bundles`);
+}
+
+const rootPkg = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+const appVersion = rootPkg.version || '0.0.0';
+
+function gitCommit() {
+  // GitHub Actions provides the SHA directly; fall back to git for local builds.
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/* --------------------------- build metadata --------------------------- */
+
+// Timestamps and commit are staged into a temp directory rather than written
+// into the working tree, so a build never leaves generated files behind for
+// someone to commit by accident.
+const stage = mkdtempSync(path.join(tmpdir(), 'scirepl-pkg-'));
+
+/**
+ * Paths under `www/` that are omitted from the **packaged desktop artifact**,
+ * as `path.relative(WWW_ROOT, …)` prefixes.
+ *
+ * >  This filter applies ONLY to the copy staged into the .exe. It does not
+ * >  touch the repository, and it does not affect the website: `www/pro/**`
+ * >  remains tracked in git and is still published by
+ * >  `.github/workflows/deploy-pages.yml`, whose trigger is unchanged. The Pro
+ * >  landing page is required and is not going anywhere.
+ *
+ * `pro/` is the Pro **landing page** — marketing copy, a separate privacy
+ * policy, a testing page, and ~800 kB of Pro branding (app icon and Play Store
+ * feature graphic). It is in this repository so GitHub Pages can serve it, not
+ * because the Free application uses it: nothing under `www/js` links to it, and
+ * the shell never navigates there.
+ *
+ * It is left out of the desktop preview because that artifact is Free-only —
+ * shipping Pro branding inside a Free build to a tester adds no function and
+ * misrepresents what they are running. The absence is asserted after packaging.
+ */
+const EXCLUDED_FROM_PACKAGE = ['pro'];
+
+// Stage a filtered copy of the application tree. `extraResource` copies whole
+// directories, so filtering has to happen before the packager sees it. The
+// source tree is only read, never modified.
+const stagedWww = path.join(stage, 'www');
+cpSync(WWW_ROOT, stagedWww, {
+  recursive: true,
+  filter: (src) => {
+    const rel = path.relative(WWW_ROOT, src);
+    if (!rel) return true;
+    return !EXCLUDED_FROM_PACKAGE.some(
+      (ex) => rel === ex || rel.startsWith(ex + path.sep)
+    );
+  },
+});
+
+const buildInfoPath = path.join(stage, 'build-info.json');
+const buildInfo = {
+  appVersion,
+  profile,
+  edition: 'free',
+  channel: 'preview',
+  commit: gitCommit(),
+  builtAt: new Date().toISOString(),
+  electron: JSON.parse(
+    readFileSync(path.join(ELECTRON_DIR, 'package.json'), 'utf8')
+  ).devDependencies.electron,
+  note: 'Unsigned portable preview. Not a release build; not Store packaging.',
+};
+writeFileSync(buildInfoPath, JSON.stringify(buildInfo, null, 2));
+
+console.log('[build-portable] packaging');
+for (const [k, v] of Object.entries({ platform, arch, appVersion, profile, commit: buildInfo.commit })) {
+  console.log(`  ${k.padEnd(12)} ${v}`);
+}
+
+/* ------------------------------ package ------------------------------- */
+
+const appPaths = await packager({
+  dir: ELECTRON_DIR,
+  out: OUT_DIR,
+  name: 'SciREPL',
+  platform,
+  arch,
+  appVersion,
+  buildVersion: appVersion,
+  overwrite: true,
+  asar: true,
+  // Strip devDependencies from the packaged app. Electron itself is a
+  // devDependency here, so without this the runtime would be shipped twice.
+  prune: true,
+  // The app is just the shell's own source. Everything else in this directory
+  // is build/test machinery and must not reach a tester's machine.
+  ignore: [
+    /^\/node_modules($|\/)/,
+    /^\/test($|\/)/,
+    /^\/packaging($|\/)/,
+    /^\/scripts($|\/)/, // dev-windows.mjs is setup machinery, not app code
+    /^\/out($|\/)/,
+    /^\/README\.md$/,
+    /^\/package-lock\.json$/,
+  ],
+  extraResource: [stagedWww, buildInfoPath],
+  win32metadata: {
+    CompanyName: 'SciREPL',
+    FileDescription: 'SciREPL — scientific REPL (Free, unsigned preview)',
+    ProductName: 'SciREPL',
+    OriginalFilename: 'SciREPL.exe',
+  },
+  // Quieter output; packager is chatty about every file it copies.
+  quiet: true,
+});
+
+rmSync(stage, { recursive: true, force: true });
+
+const appDir = appPaths[0];
+
+/* ------------------------------- verify ------------------------------- */
+
+// Assert the layout main.js depends on actually exists. A packaging change that
+// silently moves www/ produces an app that opens a window and 404s everything,
+// which is exactly the failure worth catching here rather than on Windows.
+const expectedExe = platform === 'win32' ? 'SciREPL.exe' : 'SciREPL';
+const checks = [
+  [path.join(appDir, expectedExe), 'the launchable executable'],
+  [path.join(appDir, 'resources', 'app.asar'), 'the packaged shell'],
+  [path.join(appDir, 'resources', 'www', 'index.html'), 'the application entry point'],
+  [path.join(appDir, 'resources', 'www', 'js', 'kernel_config.js'), 'the build profile'],
+  [path.join(appDir, 'resources', 'build-info.json'), 'build metadata'],
+];
+const missing = checks.filter(([p]) => !existsSync(p));
+if (missing.length) {
+  fail(`Packaged layout is wrong. Missing:\n` + missing.map(([p, what]) => `  ${what}: ${p}`).join('\n'));
+}
+
+// The Free boundary again, this time against what was actually produced.
+if (existsSync(path.join(appDir, 'resources', 'www', 'vendor', 'webr'))) {
+  fail('The packaged output contains the Pro offline R runtime. Refusing to continue.');
+}
+for (const excluded of EXCLUDED_FROM_PACKAGE) {
+  if (existsSync(path.join(appDir, 'resources', 'www', excluded))) {
+    fail(`The packaged output contains www/${excluded}, which must not ship in the Free preview.`);
+  }
+}
+
+function dirSize(dir) {
+  let total = 0;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    total += e.isDirectory() ? dirSize(p) : statSync(p).size;
+  }
+  return total;
+}
+
+console.log(`\n[build-portable] done`);
+console.log(`  output   ${appDir}`);
+console.log(`  exe      ${path.join(appDir, expectedExe)}`);
+console.log(`  size     ${(dirSize(appDir) / 1e6).toFixed(1)} MB unpacked`);
+console.log(`\n  Unsigned preview — Windows SmartScreen will warn on first run.`);
+
+// Emit the path so CI can pick it up without guessing the directory name.
+if (process.env.GITHUB_OUTPUT) {
+  writeFileSync(process.env.GITHUB_OUTPUT, `app-dir=${appDir}\n`, { flag: 'a' });
+}

--- a/desktop/electron/paths.js
+++ b/desktop/electron/paths.js
@@ -1,0 +1,61 @@
+/**
+ * paths.js — where the shell finds its content, in either layout.
+ *
+ * The shell runs in two quite different shapes and it must not guess which:
+ *
+ *   development   desktop/electron/main.js sits inside the repository, and the
+ *                 prepared application tree is <repo>/www.
+ *   packaged      main.js is inside resources/app.asar, so `__dirname` no longer
+ *                 has a repository above it. The application tree is shipped
+ *                 alongside as resources/www, deliberately OUTSIDE the asar
+ *                 archive — `net.fetch(file://…)` in protocol.js reads real
+ *                 files and does not go through Electron's asar layer, and the
+ *                 kernel runtimes are large enough that packing them would only
+ *                 slow startup.
+ *
+ * Getting this wrong is silent: the window opens and every asset 404s. So the
+ * resolvers are pure functions, exported and unit-tested rather than inlined
+ * into main.js where they could only be checked by launching the app.
+ */
+
+const path = require('path');
+
+/**
+ * Resolve the prepared `www/` tree.
+ *
+ * @param {object} layout
+ * @param {boolean} layout.isPackaged   `app.isPackaged`
+ * @param {string}  layout.resourcesPath `process.resourcesPath` (packaged only)
+ * @param {string}  layout.moduleDir    directory containing main.js
+ * @param {object}  [layout.env]        environment, for the SCIREPL_WWW override
+ * @returns {string} absolute path
+ */
+function resolveWwwRoot({ isPackaged, resourcesPath, moduleDir, env = {} }) {
+  // An explicit override always wins — the tests use it to point the shell at a
+  // fixture tree, and it is the documented way to run against a different build.
+  if (env.SCIREPL_WWW) return path.resolve(env.SCIREPL_WWW);
+
+  if (isPackaged) return path.join(resourcesPath, 'www');
+
+  // Development: <repo>/desktop/electron/main.js -> <repo>/www
+  return path.join(path.resolve(moduleDir, '..', '..'), 'www');
+}
+
+/**
+ * Resolve `build-info.json`, written by the packaging script.
+ *
+ * It exists only in packaged builds. In development the same facts are read
+ * from the repository (package.json, kernel_config.js), so a missing file here
+ * is normal and must not be treated as an error.
+ */
+function resolveBuildInfoPath({ isPackaged, resourcesPath, moduleDir }) {
+  if (isPackaged) return path.join(resourcesPath, 'build-info.json');
+  return path.join(moduleDir, 'build-info.json');
+}
+
+/** Repository root — meaningful only in development. */
+function resolveRepoRoot({ isPackaged, moduleDir }) {
+  return isPackaged ? null : path.resolve(moduleDir, '..', '..');
+}
+
+module.exports = { resolveWwwRoot, resolveBuildInfoPath, resolveRepoRoot };

--- a/desktop/electron/preload.js
+++ b/desktop/electron/preload.js
@@ -57,6 +57,26 @@ const api = {
 
 contextBridge.exposeInMainWorld('sciREPLPlatform', Object.freeze(api));
 
+/**
+ * Ask Chromium to make this origin's storage exempt from eviction.
+ *
+ * Chromium storage is "best-effort" by default: under disk pressure it may
+ * discard an origin's IndexedDB, which here means the user's notebooks and
+ * SharedVFS contents. `navigator.storage.persist()` is what marks an origin
+ * durable, and nothing was calling it — measured, not assumed.
+ *
+ * This lives in the preload rather than in the application because `www/` is
+ * shared with the PWA and the Android build and is deliberately not modified by
+ * the shell. Durability is a property of *this container*, so the container
+ * asks for it. It runs in the isolated world, changes nothing the page can see,
+ * and exposes no new surface: storage permission is per-origin, so requesting
+ * it here applies to the document.
+ *
+ * Best-effort and non-blocking. If it is refused the application still works;
+ * it is simply back to evictable storage, which is what the PWA has.
+ */
+navigator.storage?.persist?.().catch(() => { /* durability is a bonus, not a requirement */ });
+
 // Nothing is exported: this file runs as a sandboxed preload, which cannot
 // `require` relative modules. The channel names above are duplicated in
 // ipc.js, which owns the canonical allowlist; test/preload-boundary.test.mjs

--- a/desktop/electron/profile-guard.js
+++ b/desktop/electron/profile-guard.js
@@ -1,0 +1,65 @@
+/**
+ * profile-guard.js — decide whether the Free launcher may reuse an existing
+ * build configuration.
+ *
+ * `npm run dev:windows` used to skip configuration whenever
+ * `www/js/kernel_config.js` existed, without checking *which* profile it
+ * described. A checkout previously configured with `BUILD_PROFILE=pro` would
+ * therefore launch, identify itself as the Free Electron edition, and keep
+ * Pro-only runtime content such as `www/vendor/webr`.
+ *
+ * The decision is a pure function so it can be unit-tested on any platform,
+ * without running npm or launching anything — the launcher itself is hard to
+ * test, but this is the part that was wrong.
+ */
+
+/** Profiles the Free launcher is willing to prepare. */
+const FREE_PROFILES = ['mini', 'light', 'full'];
+
+/** Runtime content that only the Pro profile bundles. */
+const PRO_ONLY_RUNTIME_DIRS = ['webr'];
+
+/**
+ * @param {object} state
+ * @param {string|null} state.existingProfile  profile in the generated config, or null
+ * @param {string} state.intendedProfile       the profile this launch wants
+ * @param {boolean} [state.force]
+ * @returns {{ action: 'configure'|'skip', reason: string }}
+ */
+function decideConfiguration({ existingProfile, intendedProfile, force = false }) {
+  if (force) {
+    return { action: 'configure', reason: '--force was given' };
+  }
+  if (!existingProfile) {
+    return { action: 'configure', reason: 'no build profile is configured yet' };
+  }
+  if (existingProfile === 'unknown') {
+    return { action: 'configure', reason: 'the generated config has no readable profile' };
+  }
+  if (existingProfile !== intendedProfile) {
+    // Covers the Pro case and any other mismatch: a tree configured for one
+    // profile must not be launched as another, or the app misreports what it is
+    // and may carry runtimes the profile does not include.
+    return {
+      action: 'configure',
+      reason: `configured profile is '${existingProfile}', but this launch wants '${intendedProfile}'`,
+    };
+  }
+  return { action: 'skip', reason: `already configured for '${intendedProfile}'` };
+}
+
+/**
+ * Is this a profile the Free launcher may prepare?
+ * `pro` is rejected outright rather than reconfigured, because selecting it is
+ * a deliberate act and silently overwriting it would destroy someone's setup.
+ */
+function isFreeProfile(profile) {
+  return FREE_PROFILES.includes(profile);
+}
+
+module.exports = {
+  FREE_PROFILES,
+  PRO_ONLY_RUNTIME_DIRS,
+  decideConfiguration,
+  isFreeProfile,
+};

--- a/desktop/electron/runtime-cache.js
+++ b/desktop/electron/runtime-cache.js
@@ -54,6 +54,58 @@ const CACHEABLE_HOSTS = new Set([
   'files.pythonhosted.org',
 ]);
 
+/**
+ * Requests that must never be cached, because the resource behind them changes.
+ *
+ * `repo.r-wasm.org` is a **mutable package repository**: its `PACKAGES` indexes
+ * list what is currently available and at which version. Caching those forever
+ * would freeze the catalogue at whatever it happened to be on the day a user
+ * first installed something — so `install.packages()` would keep offering stale
+ * versions, and any future update checker would be reading a permanent snapshot
+ * and reporting "up to date" indefinitely.
+ *
+ * A query string is treated the same way: it almost always means the response
+ * is parameterised rather than a fixed asset.
+ *
+ * These pass straight through to the network, so they are correct when online
+ * and simply unavailable offline — which is the honest behaviour for "what
+ * exists right now?".
+ */
+const NEVER_CACHE = [
+  /\/PACKAGES(\.gz|\.rds)?$/i,   // R repository indexes
+  /\/PACKAGES\.json$/i,
+  /\/index\.json$/i,
+];
+
+/**
+ * Is this URL a version-pinned, immutable asset?
+ *
+ * Only these may have a **404 cached**. A "not found" is a fact about a moment
+ * in time for a mutable path — a package that does not exist today may exist
+ * tomorrow — but for a version-pinned path it is permanent, and caching it is
+ * what lets webR's `HEAD` probes for optional files answer offline.
+ *
+ *   webr.r-wasm.org/v0.5.4/...            version segment
+ *   cdn.jsdelivr.net/npm/scittle@0.6.22/  name@version
+ *   unpkg.com/fengari-web@0.1.4/...       name@version
+ *   .../ggplot2_3.5.1.tgz                 R package with version in the filename
+ *   files.pythonhosted.org/...            content-addressed by hash
+ */
+function isVersionPinned(url) {
+  if (url.hostname === 'files.pythonhosted.org') return true;
+  const p = url.pathname;
+  if (/\/v\d+\.\d+(\.\d+)?\//.test(p)) return true;      // /v0.5.4/
+  if (/@\d+\.\d+/.test(p)) return true;                    // name@1.2.3
+  if (/_\d[\w.-]*\.(tgz|tar\.gz|zip)$/i.test(p)) return true; // name_1.2.3.tgz
+  return false;
+}
+
+/** Mutable repository metadata and other responses that must stay live. */
+function isNeverCacheable(url) {
+  if (url.search) return true;
+  return NEVER_CACHE.some((re) => re.test(url.pathname));
+}
+
 /** Metadata we need to reconstruct a response. */
 const META_SUFFIX = '.meta.json';
 
@@ -166,7 +218,8 @@ function installRuntimeCache(session, options = {}) {
     const cacheable =
       (method === 'GET' || method === 'HEAD') &&
       hosts.has(url.hostname) &&
-      !range; // never cache a partial body
+      !range &&                 // never cache a partial body
+      !isNeverCacheable(url);   // never cache mutable repository metadata
 
     if (debug) {
       // To a file, not the console: the main process's stderr is swallowed by
@@ -204,11 +257,16 @@ function installRuntimeCache(session, options = {}) {
       throw err;
     }
 
-    // Cache 200 and 404. A 404 matters: webR probes for optional files, and a
-    // probe that errors offline behaves differently from one that answers "no".
-    // These hosts serve version-pinned immutable paths, so a 404 will not
-    // become a 200 later. Anything else (5xx, redirects) is passed through
-    // uncached, since it may be transient.
+    // Cache 200 always; cache 404 only for version-pinned paths.
+    //
+    // The 404 case matters because webR probes for optional files and a probe
+    // that *errors* offline behaves differently from one that answers "no". But
+    // "not found" is only permanently true for an immutable, version-pinned
+    // URL. On a mutable path — an R package that has not been published yet —
+    // caching the 404 would make it permanently non-existent for that user.
+    // Anything else (5xx, redirects) passes through uncached as possibly
+    // transient.
+    if (response.status === 404 && !isVersionPinned(url)) return response;
     if (response.status !== 200 && response.status !== 404) return response;
 
     // A HEAD has no body to read or store.
@@ -233,4 +291,7 @@ function installRuntimeCache(session, options = {}) {
   return cache;
 }
 
-module.exports = { installRuntimeCache, RuntimeCache, CACHEABLE_HOSTS, keyFor };
+module.exports = {
+  installRuntimeCache, RuntimeCache, CACHEABLE_HOSTS, keyFor,
+  isVersionPinned, isNeverCacheable, NEVER_CACHE,
+};

--- a/desktop/electron/runtime-cache.js
+++ b/desktop/electron/runtime-cache.js
@@ -1,0 +1,236 @@
+/**
+ * runtime-cache.js — a persistent on-disk cache for CDN runtimes, kept in the
+ * application's own data directory.
+ *
+ * Why this exists
+ * ---------------
+ * `www/sw.js` maintains a `CDN_CACHE` so that a runtime fetched once (Lua, R,
+ * a Pyodide mirror) keeps working offline. That mechanism cannot work in the
+ * shell: the Cache API only accepts `http`/`https` requests, and this
+ * application is served from `app://`, so every `cache.addAll()` rejects with
+ * "Request scheme 'app' is unsupported". Measured: both caches present, zero
+ * entries.
+ *
+ * Chromium's ordinary HTTP disk cache partly compensates, but only partly —
+ * measured, Lua (~200 kB) survives a restart while webR (~50 MB) does not, and
+ * raising `--disk-cache-size` to 2 GB does not change that. It is a heuristic,
+ * evictable cache that was never a promise.
+ *
+ * So the shell keeps its own. This intercepts `https` for an allowlist of
+ * runtime hosts, serves a hit straight from disk, and on a miss fetches once and
+ * writes the bytes into `userData/runtime-cache/`. That directory is the app's
+ * own storage: not evictable, not size-limited by Chromium, and it survives
+ * restarts and updates.
+ *
+ * Deliberately narrow
+ * -------------------
+ *   - Only the hosts in the allowlist are touched. Everything else is passed
+ *     straight through to `net.fetch` unmodified.
+ *   - Only `GET` is cached, only `200`, and never a range request — a partial
+ *     body written as if whole is a corrupt cache entry, which is worse than no
+ *     cache.
+ *   - Nothing is exposed to the renderer. This is main-process only and adds no
+ *     IPC surface, so it does not widen the boundary described in security.js.
+ */
+
+const { net } = require('electron');
+const crypto = require('crypto');
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+
+/**
+ * Hosts whose responses may be cached. These are the runtime and package hosts
+ * from build-profiles.json and package_catalog.js — the things the service
+ * worker's CDN_CACHE was for. Deliberately a subset of protocol.js's
+ * REMOTE_ORIGINS: the GitHub API and similar are reachable but must not be
+ * cached, since their responses change.
+ */
+const CACHEABLE_HOSTS = new Set([
+  'cdn.jsdelivr.net',
+  'unpkg.com',
+  'repo.r-wasm.org',
+  'webr.r-wasm.org',
+  'files.pythonhosted.org',
+]);
+
+/** Metadata we need to reconstruct a response. */
+const META_SUFFIX = '.meta.json';
+
+/**
+ * Cache key. The method is part of it because webR probes its virtual
+ * filesystem with HEAD before fetching with GET, and the two have different
+ * bodies (a HEAD has none) but the same URL.
+ */
+function keyFor(url, method = 'GET') {
+  return crypto.createHash('sha256').update(`${method} ${url}`).digest('hex');
+}
+
+/** Headers worth preserving on a replay. */
+const PRESERVED_HEADERS = ['content-type', 'content-encoding', 'access-control-allow-origin'];
+
+class RuntimeCache {
+  constructor(cacheDir, { log = () => {} } = {}) {
+    this.dir = cacheDir;
+    this.log = log;
+    this.stats = { hits: 0, misses: 0, stored: 0, bypassed: 0, errors: 0 };
+    fs.mkdirSync(this.dir, { recursive: true });
+  }
+
+  _paths(url, method = 'GET') {
+    const key = keyFor(url, method);
+    return {
+      body: path.join(this.dir, key),
+      meta: path.join(this.dir, key + META_SUFFIX),
+    };
+  }
+
+  async read(url, method = 'GET') {
+    const { body, meta } = this._paths(url, method);
+    try {
+      const metaRaw = await fsp.readFile(meta, 'utf8');
+      const parsed = JSON.parse(metaRaw);
+      // A HEAD entry has no body by definition, and a cached error response
+      // (see write()) has none either.
+      const bytes = parsed.hasBody ? await fsp.readFile(body) : Buffer.alloc(0);
+      return { bytes, meta: parsed };
+    } catch {
+      return null;
+    }
+  }
+
+  async write(url, bytes, headers, { method = 'GET', status = 200 } = {}) {
+    const { body, meta } = this._paths(url, method);
+    const kept = {};
+    for (const h of PRESERVED_HEADERS) {
+      const v = headers.get(h);
+      if (v) kept[h] = v;
+    }
+    const hasBody = bytes.length > 0;
+    if (hasBody) {
+      // Write to a temp name and rename, so a crash mid-write cannot leave a
+      // truncated body that would then be served forever as a "hit".
+      const tmp = body + '.partial';
+      await fsp.writeFile(tmp, bytes);
+      await fsp.rename(tmp, body);
+    }
+    // The metadata is written last, and read() keys off it, so a body without
+    // metadata is simply never treated as a hit.
+    await fsp.writeFile(meta, JSON.stringify({
+      url, method, status, headers: kept, hasBody,
+      bytes: bytes.length, storedAt: new Date().toISOString(),
+    }));
+    this.stats.stored++;
+  }
+
+  async size() {
+    let total = 0;
+    let entries = 0;
+    for (const name of await fsp.readdir(this.dir).catch(() => [])) {
+      if (name.endsWith(META_SUFFIX) || name.endsWith('.partial')) continue;
+      const st = await fsp.stat(path.join(this.dir, name)).catch(() => null);
+      if (st) { total += st.size; entries++; }
+    }
+    return { bytes: total, entries };
+  }
+
+  async clear() {
+    await fsp.rm(this.dir, { recursive: true, force: true });
+    fs.mkdirSync(this.dir, { recursive: true });
+  }
+}
+
+/**
+ * Install the cache on a session.
+ *
+ * @param {Electron.Session} session
+ * @param {object} options
+ * @param {string} options.cacheDir  directory inside userData
+ * @param {Set<string>} [options.hosts]
+ * @param {Function} [options.log]
+ * @returns {RuntimeCache}
+ */
+function installRuntimeCache(session, options = {}) {
+  const hosts = options.hosts || CACHEABLE_HOSTS;
+  const cache = new RuntimeCache(options.cacheDir, { log: options.log });
+  const debug = process.env.SCIREPL_RUNTIME_CACHE_DEBUG === '1';
+  const log = options.log || (() => {});
+
+  session.protocol.handle('https', async (request) => {
+    const url = new URL(request.url);
+
+    const range = request.headers.get('range');
+    // webR probes its virtual filesystem with HEAD before fetching with GET, so
+    // both must be cached or the probes hit the network and fail offline.
+    const method = request.method;
+    const cacheable =
+      (method === 'GET' || method === 'HEAD') &&
+      hosts.has(url.hostname) &&
+      !range; // never cache a partial body
+
+    if (debug) {
+      // To a file, not the console: the main process's stderr is swallowed by
+      // the test driver, which is exactly when this is most needed.
+      try {
+        fs.appendFileSync(path.join(options.cacheDir, '..', 'runtime-cache-debug.log'),
+          `${cacheable ? 'CACHEABLE' : 'BYPASS   '} ${method} ` +
+          `${range ? `(range ${range}) ` : ''}${request.url}\n`);
+      } catch { /* diagnostics must never break the request */ }
+    }
+
+    if (!cacheable) {
+      cache.stats.bypassed++;
+      // Pass through untouched. bypassCustomProtocolHandlers stops this call
+      // from re-entering this same handler.
+      return net.fetch(request, { bypassCustomProtocolHandlers: true });
+    }
+
+    const hit = await cache.read(request.url, method);
+    if (hit) {
+      cache.stats.hits++;
+      return new Response(hit.meta.hasBody ? hit.bytes : null, {
+        status: hit.meta.status || 200,
+        headers: hit.meta.headers || {},
+      });
+    }
+
+    cache.stats.misses++;
+    let response;
+    try {
+      response = await net.fetch(request, { bypassCustomProtocolHandlers: true });
+    } catch (err) {
+      // Offline with nothing cached: fail the way the network would.
+      cache.stats.errors++;
+      throw err;
+    }
+
+    // Cache 200 and 404. A 404 matters: webR probes for optional files, and a
+    // probe that errors offline behaves differently from one that answers "no".
+    // These hosts serve version-pinned immutable paths, so a 404 will not
+    // become a 200 later. Anything else (5xx, redirects) is passed through
+    // uncached, since it may be transient.
+    if (response.status !== 200 && response.status !== 404) return response;
+
+    // A HEAD has no body to read or store.
+    const buf = method === 'HEAD'
+      ? Buffer.alloc(0)
+      : Buffer.from(await response.arrayBuffer());
+
+    cache.write(request.url, buf, response.headers, { method, status: response.status })
+      .catch((e) => {
+        cache.stats.errors++;
+        log('runtime-cache write failed', String(e && e.message));
+      });
+
+    const headers = {};
+    for (const h of PRESERVED_HEADERS) {
+      const v = response.headers.get(h);
+      if (v) headers[h] = v;
+    }
+    return new Response(buf.length ? buf : null, { status: response.status, headers });
+  });
+
+  return cache;
+}
+
+module.exports = { installRuntimeCache, RuntimeCache, CACHEABLE_HOSTS, keyFor };

--- a/desktop/electron/scripts/dev-windows.mjs
+++ b/desktop/electron/scripts/dev-windows.mjs
@@ -23,10 +23,14 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ELECTRON_DIR = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const { decideConfiguration, isFreeProfile, FREE_PROFILES, PRO_ONLY_RUNTIME_DIRS } =
+  createRequire(import.meta.url)(path.join(
+    path.resolve(fileURLToPath(new URL('..', import.meta.url))), 'profile-guard.js'));
 const REPO_ROOT = path.resolve(ELECTRON_DIR, '..', '..');
 const WWW_ROOT = path.join(REPO_ROOT, 'www');
 
@@ -110,12 +114,63 @@ if (process.platform === 'win32' && /^\\\\/.test(REPO_ROOT)) {
 /* ------------------------- 2. build profile ---------------------------- */
 
 const kernelConfig = path.join(WWW_ROOT, 'js', 'kernel_config.js');
-if (force || !existsSync(kernelConfig)) {
-  heading('Configuring the Free build profile');
-  run('npm', ['run', 'configure'], { what: 'npm run configure' });
-} else {
+
+/** The profile in the generated config, or null when there is none. */
+function configuredProfile() {
+  if (!existsSync(kernelConfig)) return null;
   const m = readFileSync(kernelConfig, 'utf8').match(/["']?profile["']?\s*:\s*["']([^"']+)["']/);
-  heading(`Build profile already configured (${m ? m[1] : 'unknown'}) — skipping`);
+  return m ? m[1] : 'unknown';
+}
+
+// The profile this launch intends to prepare. BUILD_PROFILE lets someone pick a
+// lighter Free profile; the repository default is used otherwise.
+const profiles = JSON.parse(readFileSync(path.join(REPO_ROOT, 'build-profiles.json'), 'utf8'));
+const intendedProfile = process.env.BUILD_PROFILE || profiles.default;
+
+if (!isFreeProfile(intendedProfile)) {
+  fail(
+    `This launcher only prepares Free profiles, and '${intendedProfile}' is not one.`,
+    `Free profiles: ${FREE_PROFILES.join(', ')}.`,
+    'Selecting the Pro profile is a deliberate act, so this refuses rather than',
+    'silently overwriting your configuration.'
+  );
+}
+
+// Pro-only runtime content must not be carried into a Free launch. Left in
+// place, it would be served by the Free build and make offline R appear to work
+// in an edition that does not ship it.
+const stalePro = PRO_ONLY_RUNTIME_DIRS
+  .map((d) => path.join(WWW_ROOT, 'vendor', d))
+  .filter(existsSync);
+if (stalePro.length) {
+  fail(
+    'This checkout contains Pro-only runtime content.',
+    ...stalePro.map((d) => `  ${d}`),
+    'That is bundled by the `pro` profile, not by any Free profile, so a Free',
+    'launch must not serve it. Remove the directory (or re-run',
+    '`npm run fetch:bundles` for a Free profile) and try again.'
+  );
+}
+
+const existingProfile = configuredProfile();
+const decision = decideConfiguration({ existingProfile, intendedProfile, force });
+
+if (decision.action === 'configure') {
+  heading(`Configuring the '${intendedProfile}' build profile — ${decision.reason}`);
+  // The profile is passed explicitly: relying on the repository default is what
+  // let a previously-Pro-configured tree launch as Free.
+  run('npm', ['run', 'configure', '--', intendedProfile], { what: 'npm run configure' });
+
+  const after = configuredProfile();
+  if (after !== intendedProfile) {
+    fail(
+      `Configuration did not produce the '${intendedProfile}' profile.`,
+      `www/js/kernel_config.js now reports '${after}'.`,
+      'Run `npm run configure` manually to see what happened.'
+    );
+  }
+} else {
+  heading(`Build profile already configured ('${intendedProfile}') — skipping`);
 }
 
 /* ------------------------- 3. bundled runtimes -------------------------- */

--- a/desktop/electron/scripts/dev-windows.mjs
+++ b/desktop/electron/scripts/dev-windows.mjs
@@ -1,0 +1,197 @@
+/**
+ * dev-windows.mjs — first-time setup and launch, in one command.
+ *
+ *   npm run dev:windows
+ *
+ * Does everything a fresh Windows checkout needs, in order, and stops with an
+ * actionable message rather than a stack trace when a prerequisite is missing:
+ *
+ *   1. check Node (>= 22) and report the platform
+ *   2. configure the Free build profile
+ *   3. fetch the Free bundled runtimes (~100 MB, first run only)
+ *   4. install the isolated Electron dependencies under desktop/electron/
+ *   5. provision the Electron binary deterministically
+ *   6. launch the shell
+ *
+ * It installs nothing system-wide and needs no administrator privileges.
+ * Steps that are already done are detected and skipped, so re-running it is
+ * cheap — it doubles as "just launch the thing".
+ *
+ *   --skip-launch   do the setup only
+ *   --force         redo steps even if they look complete
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ELECTRON_DIR = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const REPO_ROOT = path.resolve(ELECTRON_DIR, '..', '..');
+const WWW_ROOT = path.join(REPO_ROOT, 'www');
+
+const force = process.argv.includes('--force');
+const skipLaunch = process.argv.includes('--skip-launch');
+
+const MIN_NODE_MAJOR = 22;
+
+let step = 0;
+const say = (msg) => console.log(msg);
+const heading = (msg) => console.log(`\n[${++step}] ${msg}`);
+
+function fail(title, ...lines) {
+  console.error(`\n  ${title}\n`);
+  for (const l of lines) console.error(`  ${l}`);
+  console.error('');
+  process.exit(1);
+}
+
+/** Run a command, inheriting stdio, and stop the script if it fails. */
+function run(command, args, { cwd = REPO_ROOT, what } = {}) {
+  const res = spawnSync(command, args, {
+    cwd,
+    stdio: 'inherit',
+    // npm on Windows is npm.cmd, which is not directly executable by CreateProcess.
+    shell: process.platform === 'win32',
+  });
+  if (res.error && res.error.code === 'ENOENT') {
+    fail(`Could not run \`${command}\`.`, `It is not on PATH.`,
+      command === 'npm' ? 'Install Node.js 22 or newer from https://nodejs.org/ and reopen your terminal.' : '');
+  }
+  if (res.status !== 0) {
+    fail(`Step failed: ${what || command}`,
+      `\`${command} ${args.join(' ')}\` exited with code ${res.status}.`,
+      'The output above should say why.');
+  }
+}
+
+/* ---------------------------- 1. environment ---------------------------- */
+
+heading('Checking prerequisites');
+
+const nodeMajor = Number(process.versions.node.split('.')[0]);
+if (Number.isNaN(nodeMajor) || nodeMajor < MIN_NODE_MAJOR) {
+  fail(
+    `Node ${MIN_NODE_MAJOR} or newer is required — this is Node ${process.versions.node}.`,
+    'Install it from https://nodejs.org/ (the LTS build is fine),',
+    'then close and reopen your terminal so PATH is refreshed.'
+  );
+}
+say(`    Node ${process.versions.node}  (>= ${MIN_NODE_MAJOR} required)`);
+
+if (process.platform === 'win32') {
+  say(`    Platform win32-${process.arch} — native Windows build`);
+} else {
+  // Deliberately a warning, not an error. Running this under WSL with WSLg is a
+  // genuinely useful preview, but it launches the LINUX Electron build shown on
+  // a Windows desktop — it is not the native Windows executable, and it cannot
+  // stand in for Windows verification.
+  say(`    Platform ${process.platform}-${process.arch}`);
+  say('');
+  say('    Note: this is not Windows. The shell will still run, but you are');
+  say('    launching the Linux Electron build (via WSLg, if you are in WSL),');
+  say('    not the native Windows executable. Fine for a look at the UI;');
+  say('    not a substitute for testing on Windows.');
+}
+
+// A checkout under \\wsl.localhost or a UNC path breaks Node tooling on Windows
+// in confusing ways. Say so plainly instead of letting it fail later.
+if (process.platform === 'win32' && /^\\\\/.test(REPO_ROOT)) {
+  fail(
+    'This repository is on a UNC path.',
+    `  ${REPO_ROOT}`,
+    'Windows Node tooling and Electron do not handle \\\\wsl.localhost or network',
+    'paths reliably. Copy the repository to a local path such as',
+    '  C:\\Users\\<you>\\Projects\\SciREPL',
+    'and run this again from there.'
+  );
+}
+
+/* ------------------------- 2. build profile ---------------------------- */
+
+const kernelConfig = path.join(WWW_ROOT, 'js', 'kernel_config.js');
+if (force || !existsSync(kernelConfig)) {
+  heading('Configuring the Free build profile');
+  run('npm', ['run', 'configure'], { what: 'npm run configure' });
+} else {
+  const m = readFileSync(kernelConfig, 'utf8').match(/["']?profile["']?\s*:\s*["']([^"']+)["']/);
+  heading(`Build profile already configured (${m ? m[1] : 'unknown'}) — skipping`);
+}
+
+/* ------------------------- 3. bundled runtimes -------------------------- */
+
+const runtimeDirs = ['pyodide', 'swipl', 'scittle'];
+const missingRuntimes = runtimeDirs.filter((d) => !existsSync(path.join(WWW_ROOT, 'vendor', d)));
+if (force || missingRuntimes.length) {
+  heading('Fetching bundled runtimes (~100 MB — first run only)');
+  run('npm', ['run', 'fetch:bundles'], { what: 'npm run fetch:bundles' });
+} else {
+  heading('Bundled runtimes already present — skipping');
+}
+
+/* --------------------- 4/5. Electron, isolated + real -------------------- */
+
+const electronPkgDir = path.join(ELECTRON_DIR, 'node_modules', 'electron');
+if (force || !existsSync(electronPkgDir)) {
+  heading('Installing the isolated Electron dependencies');
+  say('    (these live under desktop/electron/, not the root package.json,');
+  say('     so the Android and PWA builds never download a Chromium runtime)');
+  run('npm', ['install'], { cwd: ELECTRON_DIR, what: 'npm install in desktop/electron' });
+} else {
+  heading('Electron dependencies already installed — skipping');
+}
+
+// electron@43 ships no postinstall: it downloads the binary lazily on first
+// require(), which would otherwise happen in the middle of something else.
+// Provision it explicitly so failures surface here, with context.
+const electronBinaryPresent = () => {
+  try {
+    const rel = readFileSync(path.join(electronPkgDir, 'path.txt'), 'utf8').trim();
+    return existsSync(path.join(electronPkgDir, 'dist', rel));
+  } catch {
+    return false;
+  }
+};
+
+if (force || !electronBinaryPresent()) {
+  heading('Downloading the Electron binary (~220 MB — first run only)');
+  run(process.execPath, [path.join(electronPkgDir, 'install.js')], {
+    cwd: ELECTRON_DIR,
+    what: 'Electron binary download',
+  });
+  if (!electronBinaryPresent()) {
+    fail(
+      'The Electron binary is still missing after the download step.',
+      `Looked under ${path.join(electronPkgDir, 'dist')}.`,
+      'If you are behind a proxy, set HTTPS_PROXY and try again, or delete',
+      '  desktop/electron/node_modules',
+      'and re-run this command.'
+    );
+  }
+} else {
+  heading('Electron binary already present — skipping');
+}
+
+/* ------------------------------ 6. launch ------------------------------- */
+
+if (skipLaunch) {
+  console.log('\nSetup complete. Launch with:  npm run dev:windows\n');
+  process.exit(0);
+}
+
+heading('Launching SciREPL');
+say('    Close the window (or press Ctrl+C here) to stop.\n');
+
+const res = spawnSync(process.execPath, [path.join(electronPkgDir, 'cli.js'), ELECTRON_DIR], {
+  cwd: ELECTRON_DIR,
+  stdio: 'inherit',
+});
+
+// A window the user closed is a normal exit; SIGINT from Ctrl+C is too.
+if (res.status !== 0 && res.status !== null) {
+  fail(
+    `SciREPL exited with code ${res.status}.`,
+    'For the main process\'s own output, run the launch diagnostic:',
+    '  node desktop/electron/test/smoke.mjs'
+  );
+}

--- a/desktop/electron/security.js
+++ b/desktop/electron/security.js
@@ -34,6 +34,24 @@ const { SCHEME, HOST } = require('./protocol');
 const EXTERNAL_SCHEMES = new Set(['https:', 'mailto:']);
 
 /**
+ * Permissions the application may hold. Everything not listed is refused.
+ *
+ * `persistent-storage` is the single exception, and it is a correction rather
+ * than a convenience. Chromium storage is "best-effort" by default and may be
+ * evicted under disk pressure; `navigator.storage.persist()` is what marks an
+ * origin exempt. A blanket denial here silently refused that request, so a
+ * desktop application whose entire point is durable notebooks was keeping them
+ * in evictable storage — measured, not assumed: `navigator.storage.persisted()`
+ * returned false and `persist()` returned false before this exception existed.
+ *
+ * Granting it confers no ability to read or write anything new. It only stops
+ * the user's own notebooks and SharedVFS contents from being discarded to
+ * reclaim disk, which is the behaviour a locally installed application should
+ * have and one of the few things it genuinely offers over the PWA.
+ */
+const ALLOWED_PERMISSIONS = new Set(['persistent-storage']);
+
+/**
  * Decide whether a URL may be handed to the system browser.
  * Exported so tests can assert the policy directly, without a live window.
  */
@@ -134,19 +152,22 @@ function applyWebContentsPolicy(contents, options = {}) {
     event.preventDefault();
   });
 
-  // 5. Deny device/permission requests wholesale. SciREPL needs none of
-  //    geolocation, camera, microphone, MIDI, USB, serial, HID or
-  //    notifications for Phase 0. Anything it does need can be added here
-  //    deliberately rather than inherited by default.
+  // 5. Deny permission requests by default, with one deliberate exception.
+  //    SciREPL needs none of geolocation, camera, microphone, MIDI, USB,
+  //    serial, HID or notifications, and anything it does need is added to
+  //    ALLOWED_PERMISSIONS explicitly rather than inherited by default.
   const session = contents.session;
   session.setPermissionRequestHandler((_wc, permission, callback) => {
-    log('denied-permission', permission);
-    callback(false);
+    const allowed = ALLOWED_PERMISSIONS.has(permission);
+    log(allowed ? 'granted-permission' : 'denied-permission', permission);
+    callback(allowed);
   });
   session.setPermissionCheckHandler((_wc, permission) => {
-    log('denied-permission-check', permission);
-    return false;
+    const allowed = ALLOWED_PERMISSIONS.has(permission);
+    log(allowed ? 'granted-permission-check' : 'denied-permission-check', permission);
+    return allowed;
   });
+  // Device access (USB/serial/HID/Bluetooth) stays refused outright.
   session.setDevicePermissionHandler(() => false);
 
   return contents;

--- a/desktop/electron/test/harness.mjs
+++ b/desktop/electron/test/harness.mjs
@@ -10,7 +10,7 @@
 import { _electron as electron, chromium } from 'playwright';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -24,6 +24,30 @@ import { ELECTRON_DIR, REPO_ROOT, WWW_ROOT } from './reporter.mjs';
 /* ------------------------------------------------------------------ */
 
 const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * On Linux, `shell.openExternal()` shells out to `xdg-open`, which hands the URL
+ * to a desktop helper and — measured on WSLg — keeps the application alive:
+ * a single external-link test made graceful shutdown time out at 20s, while the
+ * identical run without one closed in 0.1s. The Windows CI runner has no such
+ * problem.
+ *
+ * That is a property of the test host's URL handler, not of the shell, so tests
+ * put a no-op `xdg-open` first on PATH. The policy under test is untouched —
+ * `setWindowOpenHandler` still denies the window and still calls
+ * `openExternal` — only the hand-off to the desktop is stubbed.
+ */
+let stubbedPathDir = null;
+function pathWithInertUrlHandler() {
+  if (process.platform !== 'linux') return process.env.PATH;
+  if (!stubbedPathDir) {
+    stubbedPathDir = mkdtempSync(path.join(tmpdir(), 'scirepl-nourl-'));
+    const stub = path.join(stubbedPathDir, 'xdg-open');
+    writeFileSync(stub, '#!/bin/sh\nexit 0\n');
+    chmodSync(stub, 0o755);
+  }
+  return `${stubbedPathDir}${path.delimiter}${process.env.PATH}`;
+}
 
 /**
  * Absolute path to the Electron executable for THIS platform.
@@ -157,6 +181,7 @@ async function launchAny(opts = {}) {
       args,
       env: {
         ...process.env,
+        PATH: pathWithInertUrlHandler(),
         // Never let an ambient SCIREPL_WWW leak into a packaged run.
         SCIREPL_WWW: undefined,
         ...opts.env,

--- a/desktop/electron/test/harness.mjs
+++ b/desktop/electron/test/harness.mjs
@@ -93,16 +93,60 @@ function electronExecutable() {
  *   rather than fail — pass `prime: false` only when testing that gate itself.
  */
 export async function launchShell(opts = {}) {
-  const userDataDir = opts.userDataDir || mkdtempSync(path.join(tmpdir(), 'scirepl-electron-'));
+  return launchAny({
+    ...opts,
+    executablePath: electronExecutable(),
+    appArgs: [ELECTRON_DIR],
+    // Development runs are pointed at the repository's prepared tree.
+    env: { SCIREPL_WWW: opts.www || WWW_ROOT },
+    userDataPrefix: 'scirepl-electron-',
+  });
+}
+
+/**
+ * Launch a **packaged** build — the actual `SciREPL.exe` (or platform
+ * equivalent) produced by packaging/build-portable.mjs.
+ *
+ * Differences from `launchShell`, both deliberate:
+ *   - the executable IS the app, so there is no app-directory argument;
+ *   - `SCIREPL_WWW` is NOT set, so the app must find its own bundled
+ *     `resources/www`. Overriding it would test the repository tree and quietly
+ *     defeat the point of testing a package at all.
+ *
+ * @param {object} opts
+ * @param {string} opts.exePath path to the packaged executable
+ */
+export async function launchPackagedShell(opts = {}) {
+  if (!opts.exePath) throw new Error('launchPackagedShell requires { exePath }');
+  if (!existsSync(opts.exePath)) {
+    throw new Error(
+      `No packaged executable at ${opts.exePath}.\n` +
+      'Build one first:  npm run package:windows'
+    );
+  }
+  return launchAny({
+    ...opts,
+    executablePath: opts.exePath,
+    appArgs: [],
+    env: {},               // the packaged app resolves its own content
+    userDataPrefix: 'scirepl-packaged-',
+    packaged: true,
+  });
+}
+
+/** Shared launch path for both the development shell and a packaged build. */
+async function launchAny(opts = {}) {
+  const userDataDir = opts.userDataDir
+    || mkdtempSync(path.join(tmpdir(), opts.userDataPrefix || 'scirepl-'));
   const ownsUserData = !opts.userDataDir && !opts.keepUserData;
 
-  const args = [ELECTRON_DIR];
+  const args = [...(opts.appArgs || [])];
   // WSL/CI containers frequently lack a usable setuid sandbox helper. We only
   // relax this when explicitly asked, and every security probe records whether
   // it ran with the sandbox on so the report cannot overclaim.
   if (process.env.SCIREPL_ELECTRON_NO_SANDBOX === '1') args.push('--no-sandbox');
 
-  const executablePath = electronExecutable();
+  const executablePath = opts.executablePath;
   let electronApp;
   try {
     electronApp = await electron.launch({
@@ -110,8 +154,10 @@ export async function launchShell(opts = {}) {
       args,
       env: {
         ...process.env,
+        // Never let an ambient SCIREPL_WWW leak into a packaged run.
+        SCIREPL_WWW: undefined,
+        ...opts.env,
         SCIREPL_USER_DATA: userDataDir,
-        SCIREPL_WWW: opts.www || WWW_ROOT,
         ELECTRON_ENABLE_LOGGING: '1',
       },
       timeout: 120_000,
@@ -123,10 +169,11 @@ export async function launchShell(opts = {}) {
     // needed and did not have.
     throw new Error(
       `Failed to launch the Electron shell.\n` +
+      `  mode:       ${opts.packaged ? 'packaged build' : 'development shell'}\n` +
       `  executable: ${executablePath}\n` +
       `  args:       ${JSON.stringify(args)}\n` +
       `  platform:   ${process.platform}-${process.arch}\n` +
-      `  www root:   ${opts.www || WWW_ROOT}\n` +
+      `  www root:   ${opts.packaged ? '(from the package itself)' : (opts.www || WWW_ROOT)}\n` +
       `  userData:   ${userDataDir}\n` +
       `If the executable path looks wrong for this platform, the Electron install ` +
       `is incomplete. If it looks right, the main process most likely threw during ` +

--- a/desktop/electron/test/harness.mjs
+++ b/desktop/electron/test/harness.mjs
@@ -140,7 +140,10 @@ async function launchAny(opts = {}) {
     || mkdtempSync(path.join(tmpdir(), opts.userDataPrefix || 'scirepl-'));
   const ownsUserData = !opts.userDataDir && !opts.keepUserData;
 
-  const args = [...(opts.appArgs || [])];
+  // opts.extraArgs passes Chromium switches through, so behaviour that depends
+  // on engine configuration (disk cache size, GPU flags) can be measured rather
+  // than assumed.
+  const args = [...(opts.appArgs || []), ...(opts.extraArgs || [])];
   // WSL/CI containers frequently lack a usable setuid sandbox helper. We only
   // relax this when explicitly asked, and every security probe records whether
   // it ran with the sandbox on so the report cannot overclaim.

--- a/desktop/electron/test/packaged.test.mjs
+++ b/desktop/electron/test/packaged.test.mjs
@@ -168,6 +168,45 @@ export default async function run() {
     // criterion that matters most: packaging must not relax anything.
     await assertBoundary(r, page, shell.electronApp, 'packaged');
 
+    /* ---------------- DevTools is available, and costs nothing ---------------- */
+    //
+    // DevTools in the packaged build is a genuine advantage over Android, where
+    // inspecting the WebView needs chrome://inspect, USB debugging and a second
+    // machine. It is worth asserting *both* halves: that it still works once
+    // packaged (some builds disable it), and that opening it does not widen
+    // what the page can reach.
+    //
+    // It does not, and cannot: the boundary is contextIsolation + sandbox +
+    // nodeIntegration:false, which apply to whoever is typing. A user at the
+    // DevTools console has exactly what a notebook cell has — which is why this
+    // is parity with pressing F12 on the PWA, not an escalation.
+    const devtools = await shell.electronApp.evaluate(async ({ BrowserWindow }) => {
+      const wc = BrowserWindow.getAllWindows()[0].webContents;
+      wc.openDevTools({ mode: 'detach' });
+      await new Promise((r) => setTimeout(r, 2500));
+      return { open: wc.isDevToolsOpened() };
+    });
+    r.log('packaged: DevTools can be opened', devtools.open === true);
+
+    const withDevtools = await page.evaluate(() => ({
+      require: typeof window.require,
+      process: typeof window.process,
+      viaCtor: (() => {
+        try { return typeof (new Function('return process'))(); } catch { return 'blocked'; }
+      })(),
+      api: Object.keys(window.sciREPLPlatform || {}).sort(),
+    }));
+    r.log('packaged: DevTools does not expose Node',
+      withDevtools.require === 'undefined' && withDevtools.process === 'undefined'
+        && withDevtools.viaCtor !== 'object' && withDevtools.viaCtor !== 'function',
+      JSON.stringify(withDevtools));
+    r.log('packaged: DevTools does not widen the platform API',
+      JSON.stringify(withDevtools.api) === JSON.stringify(['getAppInfo', 'getDistributionInfo']));
+
+    await shell.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].webContents.closeDevTools();
+    });
+
     /* ---------------- representative bundled kernels ---------------- */
 
     const enabled = await enabledKernels(page);

--- a/desktop/electron/test/packaged.test.mjs
+++ b/desktop/electron/test/packaged.test.mjs
@@ -1,0 +1,248 @@
+/**
+ * packaged.test.mjs — verify the PACKAGED preview, not the development shell.
+ *
+ * This is the suite that answers "can someone download the ZIP, run
+ * SciREPL.exe, and get a working, still-locked-down SciREPL?". Everything here
+ * drives the real packaged binary with no repository present in the equation:
+ * `SCIREPL_WWW` is deliberately not set, so the app has to find its own bundled
+ * `resources/www` or fail.
+ *
+ * It reuses the existing probes rather than restating them —
+ * `probes/security.mjs` for the renderer/native boundary and
+ * `probes/kernels.mjs` for execution — so the packaged build is held to exactly
+ * the same standard as the development shell. A packaged app that quietly
+ * regained Node access, or lost a kernel, fails here on the same assertions.
+ *
+ *   npm run package:windows          # build it first
+ *   node desktop/electron/test/packaged.test.mjs
+ *
+ *   SCIREPL_PACKAGED_EXE=/path/to/SciREPL.exe node .../packaged.test.mjs
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  launchPackagedShell, createReporter, waitForAppReady, attachLogs, ELECTRON_DIR, APP_ORIGIN,
+} from './harness.mjs';
+import { assertBoundary } from './probes/security.mjs';
+import { KERNEL_CASES, runKernel, enabledKernels } from './probes/kernels.mjs';
+
+/** Locate the packaged executable produced by packaging/build-portable.mjs. */
+function findPackagedExe() {
+  if (process.env.SCIREPL_PACKAGED_EXE) return process.env.SCIREPL_PACKAGED_EXE;
+
+  const outDir = path.join(ELECTRON_DIR, 'out');
+  if (!existsSync(outDir)) return null;
+
+  const exeName = process.platform === 'win32' ? 'SciREPL.exe' : 'SciREPL';
+  // Prefer a build matching this host, since that is the only one we can run.
+  const preferred = `SciREPL-${process.platform}-${process.arch}`;
+  const candidates = readdirSync(outDir).sort((a, b) =>
+    (b === preferred ? 1 : 0) - (a === preferred ? 1 : 0));
+
+  for (const dir of candidates) {
+    const exe = path.join(outDir, dir, exeName);
+    if (existsSync(exe)) return exe;
+  }
+  return null;
+}
+
+/** Total size of a directory tree. */
+function dirSize(dir) {
+  let total = 0;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    total += e.isDirectory() ? dirSize(p) : statSync(p).size;
+  }
+  return total;
+}
+
+export default async function run() {
+  const r = createReporter('packaged');
+
+  const exe = findPackagedExe();
+  if (!exe) {
+    r.log('a packaged build is available to test', false,
+      'none found under desktop/electron/out — run `npm run package:windows` first');
+    return r.summary();
+  }
+
+  const appDir = path.dirname(exe);
+  const resources = path.join(appDir, 'resources');
+  r.log('packaged executable found', true, exe);
+
+  /* ---------------- static checks on the artifact ---------------- */
+
+  r.log('the app ships its own www/ tree',
+    existsSync(path.join(resources, 'www', 'index.html')),
+    path.join(resources, 'www', 'index.html'));
+  r.log('the shell itself is packed into an asar',
+    existsSync(path.join(resources, 'app.asar')));
+
+  // Free-only boundary, asserted against what would actually be distributed.
+  const webrDir = path.join(resources, 'www', 'vendor', 'webr');
+  r.log('the artifact contains no offline R runtime (that is the Pro profile)',
+    !existsSync(webrDir), webrDir);
+
+  const proDirs = ['pro', 'Pro'].map((d) => path.join(resources, 'www', d)).filter(existsSync);
+  r.log('the artifact contains no Pro application directory',
+    proDirs.length === 0, proDirs.join(', '));
+
+  let buildInfo = null;
+  try {
+    buildInfo = JSON.parse(readFileSync(path.join(resources, 'build-info.json'), 'utf8'));
+  } catch { /* reported below */ }
+  r.log('build metadata is present in the packaged layout', buildInfo !== null);
+  r.log('build metadata reports the Free edition',
+    buildInfo && buildInfo.edition === 'free', JSON.stringify(buildInfo));
+  r.log('build metadata reports a non-Pro profile',
+    buildInfo && buildInfo.profile !== 'pro', buildInfo && buildInfo.profile);
+  r.log('build metadata marks this a preview, not a release',
+    buildInfo && buildInfo.channel === 'preview', buildInfo && buildInfo.channel);
+
+  // Build machinery must not reach a tester's machine.
+  for (const leaked of ['test', 'packaging', 'node_modules']) {
+    r.log(`the artifact does not ship desktop/electron/${leaked}`,
+      !existsSync(path.join(resources, 'app', leaked)));
+  }
+
+  r.log('artifact size measured', true, `${(dirSize(appDir) / 1e6).toFixed(1)} MB unpacked`);
+
+  /* ---------------- the packaged app actually runs ---------------- */
+
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'scirepl-pkg-run-'));
+  let shell = await launchPackagedShell({ exePath: exe, userDataDir });
+  const logs = attachLogs(shell.page);
+
+  try {
+    const { page } = shell;
+
+    const url = page.url();
+    r.log('the packaged app loads app://scirepl/index.html',
+      url === `${APP_ORIGIN}/index.html`, url);
+
+    await waitForAppReady(page);
+    r.log('the application booted inside the package', true);
+
+    const origin = await page.evaluate(() => window.location.origin);
+    r.log('the packaged origin is the same stable app origin', origin === APP_ORIGIN, origin);
+
+    const secure = await page.evaluate(() => window.isSecureContext);
+    r.log('the packaged origin is a Secure Context', secure === true, String(secure));
+
+    // The app must be serving its OWN www/, not a repository tree.
+    const servesOwnTree = await page.evaluate(async () => {
+      const res = await fetch('js/kernel_config.js');
+      return { ok: res.ok, type: res.headers.get('content-type') };
+    });
+    r.log('the packaged app serves its bundled assets',
+      servesOwnTree.ok === true, JSON.stringify(servesOwnTree));
+
+    // Version and profile must survive the packaged layout — this is what
+    // breaks if main.js keeps deriving paths from a repository that is gone.
+    const info = await page.evaluate(async () => ({
+      app: await window.sciREPLPlatform.getAppInfo(),
+      dist: await window.sciREPLPlatform.getDistributionInfo(),
+    }));
+    r.log('the packaged app reports itself as packaged',
+      info.app.packaged === true && info.dist.packaged === true, JSON.stringify(info.app));
+    r.log('the application version resolves in the packaged layout',
+      typeof info.app.appVersion === 'string'
+        && info.app.appVersion !== '0.0.0'
+        && info.app.appVersion === (buildInfo && buildInfo.appVersion),
+      info.app.appVersion);
+    r.log('the build profile resolves in the packaged layout',
+      info.dist.profile && info.dist.profile !== 'unknown' && info.dist.profile !== 'pro',
+      info.dist.profile);
+    r.log('the packaged app reports the Free edition',
+      info.dist.edition === 'free', JSON.stringify(info.dist));
+    r.log('the packaged app fabricates no entitlement', info.dist.store === null);
+    r.log('build provenance is reportable from the packaged app',
+      typeof info.dist.commit === 'string' && info.dist.commit.length > 0,
+      info.dist.commit);
+
+    /* ---------------- the security boundary, unchanged ---------------- */
+    //
+    // The same probes the development shell is held to. This is the acceptance
+    // criterion that matters most: packaging must not relax anything.
+    await assertBoundary(r, page, shell.electronApp, 'packaged');
+
+    /* ---------------- representative bundled kernels ---------------- */
+
+    const enabled = await enabledKernels(page);
+    r.log('the packaged build enables the expected Free kernel set',
+      enabled.length > 0, enabled.join(','));
+
+    // Bundled (non-network) kernels only. A preview must not be judged on CDN
+    // runtimes: the service worker cache is inert under app:// (see
+    // docs/WINDOWS_ELECTRON_SPIKE.md §5), so those need the network every run
+    // and are not part of what this artifact guarantees.
+    const bundledCases = KERNEL_CASES.filter((k) => !k.network && enabled.includes(k.lang));
+    for (const kase of bundledCases) {
+      const res = await runKernel(page, kase, 180_000);
+      r.log(`packaged: ${kase.label} runs`, res.status === 'ok',
+        res.status === 'ok' ? `init ${res.initMs}ms, exec ${res.execMs}ms`
+                            : `${res.status} ${res.error || ''}`);
+      if (res.status === 'ok' && !kase.knownIssue) {
+        r.log(`packaged: ${kase.label} produces expected output`,
+          kase.expect.test(res.output || ''), JSON.stringify(res.output || ''));
+      }
+    }
+
+    /* ---------------- SharedVFS + persistence marker ---------------- */
+
+    const marker = `packaged-preview-${Date.now()}`;
+    const wrote = await page.evaluate(async (m) => {
+      const vfs = window.sharedVFS;
+      vfs.writeFile('/shared/packaged.txt', m, 'test');
+      await vfs.saveToIndexedDB();
+      localStorage.setItem('scirepl_packaged_marker', m);
+      return {
+        vfs: vfs.readFile('/shared/packaged.txt') === m,
+        ls: localStorage.getItem('scirepl_packaged_marker') === m,
+      };
+    }, marker);
+    r.log('packaged: SharedVFS round-trips', wrote.vfs === true, JSON.stringify(wrote));
+
+    const pageErrors = logs.filter((l) => l.startsWith('[pageerror]'));
+    r.log('no uncaught page errors in the packaged app',
+      pageErrors.length === 0, pageErrors.slice(0, 3).join(' | '));
+
+    /* ---------------- restart the packaged app ---------------- */
+
+    const { timedOut } = await shell.close();
+    r.log('the packaged app shuts down gracefully', timedOut === false,
+      timedOut ? 'close() timed out and needed SIGKILL' : '');
+
+    shell = await launchPackagedShell({ exePath: exe, userDataDir });
+    await waitForAppReady(shell.page);
+
+    const restored = await shell.page.evaluate(async (m) => {
+      const out = { ls: localStorage.getItem('scirepl_packaged_marker') === m };
+      try {
+        const vfs = window.sharedVFS;
+        if (typeof vfs.loadFromIndexedDB === 'function') await vfs.loadFromIndexedDB();
+        out.vfs = vfs.readFile('/shared/packaged.txt') === m;
+      } catch (e) {
+        out.vfs = false;
+        out.error = String(e && e.message);
+      }
+      return out;
+    }, marker);
+
+    r.log('SharedVFS state survives a packaged-app restart',
+      restored.vfs === true, restored.error || '');
+    r.log('notebook/localStorage state survives a packaged-app restart',
+      restored.ls === true);
+  } finally {
+    await shell.close();
+    try { rmSync(userDataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then((s) => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/packaged.test.mjs
+++ b/desktop/electron/test/packaged.test.mjs
@@ -250,9 +250,23 @@ export default async function run() {
 
     /* ---------------- restart the packaged app ---------------- */
 
+    // Report what the app looked like going in, so a shutdown failure says why
+    // rather than just "timed out".
+    const preClose = await shell.electronApp.evaluate(({ BrowserWindow }) => {
+      const wins = BrowserWindow.getAllWindows();
+      return {
+        windows: wins.length,
+        devtoolsOpen: wins[0] ? wins[0].webContents.isDevToolsOpened() : null,
+        titles: wins.map((w) => w.getTitle()),
+      };
+    });
+    const closeStarted = Date.now();
     const { timedOut } = await shell.close();
+    const closeSeconds = ((Date.now() - closeStarted) / 1000).toFixed(1);
     r.log('the packaged app shuts down gracefully', timedOut === false,
-      timedOut ? 'close() timed out and needed SIGKILL' : '');
+      timedOut
+        ? `close() timed out after ${closeSeconds}s and needed SIGKILL — state going in: ${JSON.stringify(preClose)}`
+        : `${closeSeconds}s`);
 
     shell = await launchPackagedShell({ exePath: exe, userDataDir });
     await waitForAppReady(shell.page);

--- a/desktop/electron/test/persistence.test.mjs
+++ b/desktop/electron/test/persistence.test.mjs
@@ -79,6 +79,22 @@ export default async function run() {
       }, MARKER);
 
       r.log('first launch: origin is the stable app origin', originFirst === 'app://scirepl', originFirst);
+
+      // Durability, not just survival. Chromium storage is "best-effort" by
+      // default and may be discarded under disk pressure; persist() is what
+      // exempts an origin. A blanket permission denial in security.js silently
+      // refused it, so notebooks sat in evictable storage — measured false
+      // before the fix. Android gets this free from its private app data
+      // directory; a browser PWA does not.
+      const durability = await first.page.evaluate(async () => {
+        const est = await navigator.storage.estimate();
+        return {
+          persisted: await navigator.storage.persisted(),
+          quotaMB: Math.round((est.quota || 0) / 1e6),
+        };
+      });
+      r.log('first launch: storage is marked persistent (not evictable)',
+        durability.persisted === true, JSON.stringify(durability));
       r.log('first launch: SharedVFS write succeeded', wrote.vfsWritten === true);
       r.log('first launch: direct IndexedDB write succeeded', wrote.directIdb === true);
       r.log('first launch: localStorage write succeeded', wrote.localStorage === true);

--- a/desktop/electron/test/policy.unit.test.mjs
+++ b/desktop/electron/test/policy.unit.test.mjs
@@ -78,6 +78,50 @@ export default async function run() {
       protocol.resolveRequestPath(ROOT, input) === null);
   }
 
+  /* ---------------- packaged vs development layout ---------------- */
+
+  // Getting this wrong is silent — the window opens and every asset 404s — so
+  // it is asserted here rather than only discovered by launching a package.
+  const paths = require(path.join(ELECTRON_DIR, 'paths.js'));
+
+  const devLayout = {
+    isPackaged: false,
+    resourcesPath: '/irrelevant',
+    moduleDir: path.join(path.sep, 'repo', 'desktop', 'electron'),
+    env: {},
+  };
+  r.log('development: www/ resolves next to the repository root',
+    paths.resolveWwwRoot(devLayout) === path.join(path.sep, 'repo', 'www'),
+    paths.resolveWwwRoot(devLayout));
+  r.log('development: the repository root is known',
+    paths.resolveRepoRoot(devLayout) === path.join(path.sep, 'repo'));
+
+  const packagedLayout = {
+    isPackaged: true,
+    resourcesPath: path.join(path.sep, 'apps', 'SciREPL', 'resources'),
+    moduleDir: path.join(path.sep, 'apps', 'SciREPL', 'resources', 'app.asar'),
+    env: {},
+  };
+  r.log('packaged: www/ resolves inside resources, not via the module directory',
+    paths.resolveWwwRoot(packagedLayout)
+      === path.join(path.sep, 'apps', 'SciREPL', 'resources', 'www'),
+    paths.resolveWwwRoot(packagedLayout));
+  r.log('packaged: build-info.json resolves inside resources',
+    paths.resolveBuildInfoPath(packagedLayout)
+      === path.join(path.sep, 'apps', 'SciREPL', 'resources', 'build-info.json'));
+  r.log('packaged: there is no repository root to fall back on',
+    paths.resolveRepoRoot(packagedLayout) === null);
+
+  // The override has to win in both layouts — the tests rely on it.
+  for (const [label, layout] of [['development', devLayout], ['packaged', packagedLayout]]) {
+    const overridden = paths.resolveWwwRoot({
+      ...layout,
+      env: { SCIREPL_WWW: path.join(path.sep, 'custom', 'tree') },
+    });
+    r.log(`${label}: SCIREPL_WWW overrides the resolved tree`,
+      overridden === path.join(path.sep, 'custom', 'tree'), overridden);
+  }
+
   /* ---------------- external URL classification ---------------- */
 
   const allowedExternal = [

--- a/desktop/electron/test/policy.unit.test.mjs
+++ b/desktop/electron/test/policy.unit.test.mjs
@@ -84,42 +84,140 @@ export default async function run() {
   // it is asserted here rather than only discovered by launching a package.
   const paths = require(path.join(ELECTRON_DIR, 'paths.js'));
 
+  // Fixtures must be *absolute* paths for this platform. `path.join(path.sep, …)`
+  // produces a drive-relative path on Windows (`\repo`), while the resolvers
+  // return `path.resolve()` output (`D:\repo`), so the two never compare equal
+  // and the suite failed on Windows while passing on Linux. `path.resolve()` on
+  // both sides keeps the comparison platform-correct.
+  const REPO = path.resolve('/repo');
+  const APP_RES = path.resolve('/apps/SciREPL/resources');
+  const CUSTOM = path.resolve('/custom/tree');
+
   const devLayout = {
     isPackaged: false,
-    resourcesPath: '/irrelevant',
-    moduleDir: path.join(path.sep, 'repo', 'desktop', 'electron'),
+    resourcesPath: path.resolve('/irrelevant'),
+    moduleDir: path.join(REPO, 'desktop', 'electron'),
     env: {},
   };
   r.log('development: www/ resolves next to the repository root',
-    paths.resolveWwwRoot(devLayout) === path.join(path.sep, 'repo', 'www'),
+    paths.resolveWwwRoot(devLayout) === path.join(REPO, 'www'),
     paths.resolveWwwRoot(devLayout));
   r.log('development: the repository root is known',
-    paths.resolveRepoRoot(devLayout) === path.join(path.sep, 'repo'));
+    paths.resolveRepoRoot(devLayout) === REPO,
+    paths.resolveRepoRoot(devLayout));
 
   const packagedLayout = {
     isPackaged: true,
-    resourcesPath: path.join(path.sep, 'apps', 'SciREPL', 'resources'),
-    moduleDir: path.join(path.sep, 'apps', 'SciREPL', 'resources', 'app.asar'),
+    resourcesPath: APP_RES,
+    moduleDir: path.join(APP_RES, 'app.asar'),
     env: {},
   };
   r.log('packaged: www/ resolves inside resources, not via the module directory',
-    paths.resolveWwwRoot(packagedLayout)
-      === path.join(path.sep, 'apps', 'SciREPL', 'resources', 'www'),
+    paths.resolveWwwRoot(packagedLayout) === path.join(APP_RES, 'www'),
     paths.resolveWwwRoot(packagedLayout));
   r.log('packaged: build-info.json resolves inside resources',
-    paths.resolveBuildInfoPath(packagedLayout)
-      === path.join(path.sep, 'apps', 'SciREPL', 'resources', 'build-info.json'));
+    paths.resolveBuildInfoPath(packagedLayout) === path.join(APP_RES, 'build-info.json'),
+    paths.resolveBuildInfoPath(packagedLayout));
   r.log('packaged: there is no repository root to fall back on',
     paths.resolveRepoRoot(packagedLayout) === null);
 
+  // Every resolved path must be absolute on this platform — the property that
+  // actually broke on Windows, asserted directly rather than inferred.
+  for (const [label, layout] of [['development', devLayout], ['packaged', packagedLayout]]) {
+    r.log(`${label}: the resolved www/ path is absolute`,
+      path.isAbsolute(paths.resolveWwwRoot(layout)), paths.resolveWwwRoot(layout));
+  }
+
   // The override has to win in both layouts — the tests rely on it.
   for (const [label, layout] of [['development', devLayout], ['packaged', packagedLayout]]) {
-    const overridden = paths.resolveWwwRoot({
-      ...layout,
-      env: { SCIREPL_WWW: path.join(path.sep, 'custom', 'tree') },
-    });
+    const overridden = paths.resolveWwwRoot({ ...layout, env: { SCIREPL_WWW: CUSTOM } });
     r.log(`${label}: SCIREPL_WWW overrides the resolved tree`,
-      overridden === path.join(path.sep, 'custom', 'tree'), overridden);
+      overridden === CUSTOM, overridden);
+  }
+
+  /* ---------------- the Free launcher must not reuse a Pro profile ---------------- */
+  //
+  // `npm run dev:windows` used to skip configuration whenever kernel_config.js
+  // existed, without checking which profile it described — so a checkout left
+  // configured with BUILD_PROFILE=pro would launch while identifying itself as
+  // the Free Electron edition.
+  const guard = require(path.join(ELECTRON_DIR, 'profile-guard.js'));
+
+  const decisions = [
+    [{ existingProfile: 'full', intendedProfile: 'full' }, 'skip', 'correct profile is reused'],
+    [{ existingProfile: 'pro', intendedProfile: 'full' }, 'configure', 'a Pro-configured tree is reconfigured'],
+    [{ existingProfile: 'mini', intendedProfile: 'full' }, 'configure', 'any mismatched profile is reconfigured'],
+    [{ existingProfile: null, intendedProfile: 'full' }, 'configure', 'an unconfigured tree is configured'],
+    [{ existingProfile: 'unknown', intendedProfile: 'full' }, 'configure', 'an unreadable profile is reconfigured'],
+    [{ existingProfile: 'full', intendedProfile: 'full', force: true }, 'configure', '--force always reconfigures'],
+  ];
+  for (const [state, expected, what] of decisions) {
+    const got = guard.decideConfiguration(state);
+    r.log(`launcher: ${what}`, got.action === expected, `${got.action} — ${got.reason}`);
+  }
+
+  r.log('launcher: pro is not a profile the Free launcher will prepare',
+    guard.isFreeProfile('pro') === false);
+  for (const free of ['mini', 'light', 'full']) {
+    r.log(`launcher: '${free}' is a Free profile`, guard.isFreeProfile(free) === true);
+  }
+  r.log('launcher: webr is known as Pro-only runtime content',
+    guard.PRO_ONLY_RUNTIME_DIRS.includes('webr'));
+
+  /* ---------------- runtime cache: what may be kept forever ---------------- */
+  //
+  // repo.r-wasm.org is a MUTABLE package repository. Caching its PACKAGES
+  // indexes indefinitely would freeze the catalogue at first use, so
+  // install.packages() would keep offering stale versions and a future update
+  // checker would read a permanent snapshot and always report "up to date".
+  const rc = require(path.join(ELECTRON_DIR, 'runtime-cache.js'));
+  const u = (s) => new URL(s);
+
+  const neverCache = [
+    'https://repo.r-wasm.org/bin/emscripten/contrib/4.4/PACKAGES',
+    'https://repo.r-wasm.org/bin/emscripten/contrib/4.4/PACKAGES.gz',
+    'https://repo.r-wasm.org/src/contrib/PACKAGES.rds',
+    'https://repo.r-wasm.org/bin/emscripten/contrib/4.4/PACKAGES.json',
+    'https://cdn.jsdelivr.net/npm/thing?v=latest',   // parameterised
+  ];
+  for (const url of neverCache) {
+    r.log(`mutable metadata is never cached: ${url.replace('https://', '')}`,
+      rc.isNeverCacheable(u(url)) === true);
+  }
+
+  const stillCacheable = [
+    'https://webr.r-wasm.org/v0.5.4/R.wasm',
+    'https://repo.r-wasm.org/bin/emscripten/contrib/4.4/ggplot2_3.5.1.tgz',
+    'https://cdn.jsdelivr.net/npm/scittle@0.6.22/dist/scittle.js',
+  ];
+  for (const url of stillCacheable) {
+    r.log(`runtime asset is still cacheable: ${url.replace('https://', '')}`,
+      rc.isNeverCacheable(u(url)) === false);
+  }
+
+  // A 404 may only be remembered for a version-pinned path. On a mutable path a
+  // package that does not exist today may exist tomorrow, and caching the 404
+  // would make it permanently missing for that user.
+  const pinned = [
+    'https://webr.r-wasm.org/v0.5.4/vfs/usr/lib/R/library/grDevices/afm.data.gz',
+    'https://cdn.jsdelivr.net/npm/scittle@0.6.22/dist/scittle.js',
+    'https://unpkg.com/fengari-web@0.1.4/dist/fengari-web.js',
+    'https://repo.r-wasm.org/bin/emscripten/contrib/4.4/ggplot2_3.5.1.tgz',
+    'https://files.pythonhosted.org/packages/ab/cd/thing-1.0-py3-none-any.whl',
+  ];
+  for (const url of pinned) {
+    r.log(`404 may be remembered (version-pinned): ${url.replace('https://', '').slice(0, 58)}`,
+      rc.isVersionPinned(u(url)) === true);
+  }
+
+  const unpinned = [
+    'https://repo.r-wasm.org/bin/emscripten/contrib/4.4/',
+    'https://repo.r-wasm.org/src/contrib/somepackage.tgz',
+    'https://cdn.jsdelivr.net/npm/scittle/dist/scittle.js',   // no @version
+  ];
+  for (const url of unpinned) {
+    r.log(`404 must NOT be remembered (mutable): ${url.replace('https://', '').slice(0, 58)}`,
+      rc.isVersionPinned(u(url)) === false);
   }
 
   /* ---------------- external URL classification ---------------- */

--- a/desktop/electron/test/probes/security.mjs
+++ b/desktop/electron/test/probes/security.mjs
@@ -1,0 +1,200 @@
+/**
+ * probes/security.mjs — the renderer/native boundary checks, as reusable probes.
+ *
+ * Extracted from security.test.mjs so the packaged build is held to exactly the
+ * same standard as the development shell, using the same code. A packaged app
+ * that quietly regained Node access while a separate, drifting copy of the
+ * assertions kept passing is precisely the failure this arrangement prevents.
+ *
+ * Every probe takes a Playwright `Page` and returns plain data — no assertions,
+ * no reporter — so each caller decides how to grade the result.
+ *
+ * The probes are written from the notebook author's position: where possible
+ * they execute through the real JavaScript kernel, in the main world, which is
+ * how user notebook code actually runs (www/js/kernels/javascript.js).
+ */
+
+/** Run a snippet through the real JavaScript kernel, as a notebook cell would. */
+export async function runNotebookCell(page, code) {
+  return page.evaluate(async (src) => {
+    const km = window.kernelManager;
+    await km.ensureReady('javascript');
+    return await km.execute(src, 'javascript');
+  }, code);
+}
+
+/** Node globals visible on `window` in the renderer. All should be undefined. */
+export async function probeRendererNodeGlobals(page) {
+  return page.evaluate(() => ({
+    require: typeof window.require,
+    process: typeof window.process,
+    Buffer: typeof window.Buffer,
+    module: typeof window.module,
+    exports: typeof window.exports,
+    global: typeof window.global,
+    __dirname: typeof window.__dirname,
+    electron: typeof window.electron,
+    ipcRenderer: typeof window.ipcRenderer,
+  }));
+}
+
+/**
+ * The same question asked from inside a notebook cell — the case that actually
+ * matters, since notebook code shares the renderer realm with the UI.
+ * Returns a map of name -> typeof, or 'ReferenceError'.
+ */
+export async function probeNotebookNodeGlobals(page) {
+  const res = await runNotebookCell(page, `
+    const probe = {};
+    for (const name of ['require','process','Buffer','module','__dirname','global','electron','ipcRenderer']) {
+      try { probe[name] = typeof eval(name); } catch (e) { probe[name] = 'ReferenceError'; }
+    }
+    JSON.stringify(probe)
+  `);
+  try {
+    return JSON.parse(res.result?.content || '{}');
+  } catch {
+    return {};
+  }
+}
+
+/** The classic escapes: Function constructor, top, parent. */
+export async function probeNotebookEscapes(page) {
+  const res = await runNotebookCell(page, `
+    const out = {};
+    try { out.processViaCtor = typeof (new Function('return process'))(); } catch (e) { out.processViaCtor = 'blocked:' + e.name; }
+    try { out.requireViaTop = typeof top.require; } catch (e) { out.requireViaTop = 'blocked:' + e.name; }
+    try { out.requireViaParent = typeof parent.require; } catch (e) { out.requireViaParent = 'blocked:' + e.name; }
+    JSON.stringify(out)
+  `);
+  try {
+    return JSON.parse(res.result?.content || '{}');
+  } catch {
+    return {};
+  }
+}
+
+/** Anything reachable that would constitute a real capability. */
+export function reachableCapabilities(map) {
+  return Object.entries(map).filter(([, v]) => v === 'function' || v === 'object');
+}
+
+/** The exposed preload surface: shape, freeze state, and absence of hatches. */
+export async function probeExposedSurface(page) {
+  return page.evaluate(() => {
+    const api = window.sciREPLPlatform;
+    if (!api) return null;
+    const hatches = ['invoke', 'send', 'on', 'ipc', 'ipcRenderer', 'require', 'exec', 'spawn',
+      'readFile', 'writeFile', 'fs', 'shell', 'openPath', 'eval']
+      .filter((k) => typeof api[k] !== 'undefined');
+    return {
+      keys: Object.keys(api).sort(),
+      frozen: Object.isFrozen(api),
+      types: Object.fromEntries(Object.keys(api).map((k) => [k, typeof api[k]])),
+      hatches,
+    };
+  });
+}
+
+/** The two allowlisted read-only operations. */
+export async function probePlatformApi(page) {
+  return page.evaluate(async () => {
+    const appInfo = await window.sciREPLPlatform.getAppInfo();
+    const dist = await window.sciREPLPlatform.getDistributionInfo();
+    // Renderer-supplied arguments must be inert: the preload wrapper is nullary
+    // and forwards nothing.
+    const withArgs = await window.sciREPLPlatform.getAppInfo('extra', { evil: true }, 42);
+    return { appInfo, dist, argsInert: JSON.stringify(appInfo) === JSON.stringify(withArgs) };
+  });
+}
+
+/** webPreferences as the main process actually constructed the window. */
+export async function probeWebPreferences(electronApp) {
+  return electronApp.evaluate(({ BrowserWindow }) => {
+    const wc = BrowserWindow.getAllWindows()[0].webContents;
+    const p = wc.getLastWebPreferences() || {};
+    return {
+      nodeIntegration: p.nodeIntegration ?? null,
+      contextIsolation: p.contextIsolation ?? null,
+      sandbox: p.sandbox ?? null,
+      webSecurity: p.webSecurity ?? null,
+      webviewTag: p.webviewTag ?? null,
+    };
+  });
+}
+
+/**
+ * Attempt to navigate the window off the app origin from a notebook cell, and
+ * to open a new window. Neither may succeed.
+ */
+export async function probeNavigationPolicy(page, electronApp) {
+  const beforeUrl = page.url();
+  await runNotebookCell(page, `try { window.location.href = 'https://example.com/'; } catch (e) {} ; 1`);
+  await page.waitForTimeout(1500);
+  const afterUrl = page.url();
+
+  const windowsBefore = await electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+  await runNotebookCell(page, `try { window.open('https://example.com/'); } catch (e) {}; 1`);
+  await page.waitForTimeout(1500);
+  const windowsAfter = await electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+
+  return { beforeUrl, afterUrl, navigated: beforeUrl !== afterUrl, windowsBefore, windowsAfter };
+}
+
+/**
+ * Grade the core boundary probes against one page. Shared by the development
+ * and packaged suites so both enforce an identical standard.
+ *
+ * @param {object} r reporter (createReporter)
+ * @param {string} label prefix for assertion names
+ */
+export async function assertBoundary(r, page, electronApp, label = '') {
+  const p = label ? `${label}: ` : '';
+
+  const rendererGlobals = await probeRendererNodeGlobals(page);
+  const leaked = Object.entries(rendererGlobals).filter(([, v]) => v !== 'undefined');
+  r.log(`${p}no Node global is exposed on window`,
+    leaked.length === 0, JSON.stringify(rendererGlobals));
+
+  const cellGlobals = await probeNotebookNodeGlobals(page);
+  const cellLeaked = Object.entries(cellGlobals)
+    .filter(([, v]) => v !== 'undefined' && v !== 'ReferenceError');
+  r.log(`${p}a notebook cell cannot reach any Node global`,
+    cellLeaked.length === 0, JSON.stringify(cellGlobals));
+
+  const escapes = await probeNotebookEscapes(page);
+  r.log(`${p}a notebook cell cannot reach Node via Function constructor / top / parent`,
+    reachableCapabilities(escapes).length === 0, JSON.stringify(escapes));
+
+  const surface = await probeExposedSurface(page);
+  r.log(`${p}the exposed surface is exactly [getAppInfo, getDistributionInfo]`,
+    surface && JSON.stringify(surface.keys) === JSON.stringify(['getAppInfo', 'getDistributionInfo']),
+    surface && JSON.stringify(surface.keys));
+  r.log(`${p}the exposed API object is frozen`, surface?.frozen === true);
+  r.log(`${p}no generic invoke/send/fs/shell escape hatch is exposed`,
+    surface && surface.hatches.length === 0, JSON.stringify(surface && surface.hatches));
+
+  const api = await probePlatformApi(page);
+  r.log(`${p}getAppInfo returns build facts only`,
+    !!api.appInfo && typeof api.appInfo.electronVersion === 'string'
+      && !('cwd' in api.appInfo) && !('env' in api.appInfo),
+    JSON.stringify(api.appInfo));
+  r.log(`${p}renderer-supplied arguments to the platform API are inert`, api.argsInert === true);
+  r.log(`${p}no entitlement/licence value is fabricated`, api.dist.store === null,
+    JSON.stringify(api.dist.store));
+
+  const prefs = await probeWebPreferences(electronApp);
+  r.log(`${p}nodeIntegration is false`, prefs.nodeIntegration === false, String(prefs.nodeIntegration));
+  r.log(`${p}contextIsolation is true`, prefs.contextIsolation === true, String(prefs.contextIsolation));
+  r.log(`${p}sandbox is true`, prefs.sandbox === true, String(prefs.sandbox));
+  r.log(`${p}webSecurity is enabled`, prefs.webSecurity !== false, String(prefs.webSecurity));
+  r.log(`${p}webviewTag is disabled`, prefs.webviewTag === false, String(prefs.webviewTag));
+
+  const nav = await probeNavigationPolicy(page, electronApp);
+  r.log(`${p}a notebook cell cannot navigate the window off the app origin`,
+    nav.navigated === false, `${nav.beforeUrl} -> ${nav.afterUrl}`);
+  r.log(`${p}window.open does not create a new Electron window`,
+    nav.windowsAfter === nav.windowsBefore, `${nav.windowsBefore} -> ${nav.windowsAfter}`);
+
+  return { rendererGlobals, cellGlobals, escapes, surface, api, prefs, nav };
+}

--- a/desktop/electron/test/run-all.mjs
+++ b/desktop/electron/test/run-all.mjs
@@ -29,6 +29,8 @@ const SUITES = [
   // Not in the default set: it needs a built package, which most runs do not
   // have. Select it explicitly (`run-all.mjs packaged`) or via --packaged.
   { name: 'packaged', file: './packaged.test.mjs', unit: false, optIn: true },
+  // Needs live network for its online half, so it is opt-in too.
+  { name: 'runtime-cache', file: './runtime-cache.test.mjs', unit: false, optIn: true },
 ];
 
 const argv = process.argv.slice(2);

--- a/desktop/electron/test/run-all.mjs
+++ b/desktop/electron/test/run-all.mjs
@@ -26,15 +26,22 @@ const SUITES = [
   { name: 'persistence', file: './persistence.test.mjs', unit: false },
   { name: 'kernels', file: './kernels.test.mjs', unit: false },
   { name: 'offline', file: './offline.test.mjs', unit: false },
+  // Not in the default set: it needs a built package, which most runs do not
+  // have. Select it explicitly (`run-all.mjs packaged`) or via --packaged.
+  { name: 'packaged', file: './packaged.test.mjs', unit: false, optIn: true },
 ];
 
 const argv = process.argv.slice(2);
 const unitOnly = argv.includes('--unit');
+const withPackaged = argv.includes('--packaged');
 const named = argv.filter(a => !a.startsWith('--'));
 
 const selected = SUITES.filter(s => {
   if (named.length) return named.includes(s.name);
   if (unitOnly) return s.unit;
+  // Opt-in suites need something the default run does not have (the `packaged`
+  // suite needs a built package), so they are never part of a bare run.
+  if (s.optIn) return withPackaged;
   return true;
 });
 

--- a/desktop/electron/test/runtime-cache.test.mjs
+++ b/desktop/electron/test/runtime-cache.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * runtime-cache.test.mjs — CDN runtimes must survive a restart, offline.
+ *
+ * This is the suite that guards the fix for the shell's one real functional
+ * regression against the PWA. `www/sw.js` keeps a `CDN_CACHE` so a runtime
+ * fetched once keeps working offline; that cache cannot function under the
+ * `app://` origin, because the Cache API only accepts http/https. Chromium's
+ * own HTTP cache covered Lua but not webR, and raising `--disk-cache-size` to
+ * 2 GB did not change that.
+ *
+ * `runtime-cache.js` replaces it with a cache in the application's own data
+ * directory. The assertions below are the ones that matter: fetch once online,
+ * restart, cut the network, and the kernel still runs.
+ *
+ * Needs network for the first half, so it is opt-in rather than part of the
+ * default run:
+ *
+ *   node desktop/electron/test/run-all.mjs runtime-cache
+ */
+
+import { mkdtempSync, rmSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { launchShell, createReporter, waitForAppReady } from './harness.mjs';
+
+/** Cut the network at the session level, leaving app:// untouched. */
+async function goOffline(shell) {
+  await shell.electronApp.evaluate(async ({ session }) => {
+    await session.defaultSession.setProxy({ proxyRules: 'http=127.0.0.1:1;https=127.0.0.1:1' });
+    await session.defaultSession.closeAllConnections();
+  });
+}
+
+async function runKernel(page, lang, code, timeoutMs) {
+  return page.evaluate(async ({ lang, code, timeoutMs }) => {
+    try {
+      await Promise.race([
+        window.kernelManager.ensureReady(lang),
+        new Promise((_, rj) => setTimeout(() => rj(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs)),
+      ]);
+      const r = await window.kernelManager.execute(code, lang);
+      return { ok: !r.error, out: ((r.stdout || '') + (r.result?.content || '')).trim(), error: r.error || null };
+    } catch (e) {
+      return { ok: false, error: String(e && e.message).slice(0, 160) };
+    }
+  }, { lang, code, timeoutMs });
+}
+
+function cacheSize(userDataDir) {
+  const dir = path.join(userDataDir, 'runtime-cache');
+  if (!existsSync(dir)) return { entries: 0, bytes: 0 };
+  let bytes = 0;
+  let entries = 0;
+  for (const f of readdirSync(dir)) {
+    if (f.endsWith('.meta.json') || f.endsWith('.partial')) continue;
+    bytes += statSync(path.join(dir, f)).size;
+    entries++;
+  }
+  return { entries, bytes };
+}
+
+/** One kernel, end to end: online once, then offline after a real restart. */
+async function checkKernel(r, { lang, label, code, timeoutMs }) {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), `scirepl-rc-${lang}-`));
+  try {
+    let shell = await launchShell({ userDataDir });
+    try {
+      await waitForAppReady(shell.page);
+      const online = await runKernel(shell.page, lang, code, timeoutMs);
+      r.log(`${label}: runs online`, online.ok === true, online.error || online.out);
+      if (!online.ok) return; // nothing cached; the offline half would be meaningless
+    } finally {
+      await shell.close();
+    }
+
+    const size = cacheSize(userDataDir);
+    r.log(`${label}: bytes were written to userData/runtime-cache`,
+      size.entries > 0, `${size.entries} entries, ${(size.bytes / 1e6).toFixed(1)} MB`);
+
+    // Fresh process, same profile, no network.
+    shell = await launchShell({ userDataDir });
+    try {
+      await goOffline(shell);
+      await shell.page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+      await waitForAppReady(shell.page);
+
+      const remote = await shell.page.evaluate(async () => {
+        try { await fetch('https://example.com/', { cache: 'no-store' }); return 'reachable'; }
+        catch { return 'blocked'; }
+      });
+      r.log(`${label}: network really is cut for the offline half`, remote === 'blocked', remote);
+
+      const offline = await runKernel(shell.page, lang, code, timeoutMs);
+      r.log(`${label}: still runs OFFLINE after a restart`, offline.ok === true,
+        offline.error || offline.out);
+      r.log(`${label}: offline output is correct`, /42/.test(offline.out || ''),
+        JSON.stringify(offline.out || ''));
+    } finally {
+      await shell.close();
+    }
+  } finally {
+    try { rmSync(userDataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+export default async function run() {
+  const r = createReporter('runtime-cache');
+
+  // Lua is small and was already covered by Chromium's HTTP cache; R is the one
+  // that failed, and is the reason this cache exists. Both are checked so a
+  // regression in either is visible.
+  await checkKernel(r, {
+    lang: 'lua', label: 'Lua / Fengari (~200 kB)',
+    code: 'print(6*7)', timeoutMs: 90_000,
+  });
+  await checkKernel(r, {
+    lang: 'r', label: 'R / webR (~50 MB)',
+    code: 'cat(6*7)', timeoutMs: 240_000,
+  });
+
+  /* ---- the cache must not be reached without a prior online fetch ---- */
+  //
+  // Guards against the cache appearing to work because something else is
+  // serving the bytes: a profile that never went online must still fail.
+  const coldDir = mkdtempSync(path.join(tmpdir(), 'scirepl-rc-cold-'));
+  const cold = await launchShell({ userDataDir: coldDir });
+  try {
+    await waitForAppReady(cold.page);
+    await goOffline(cold);
+    await cold.page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+    await waitForAppReady(cold.page);
+    const res = await runKernel(cold.page, 'lua', 'print(6*7)', 45_000);
+    r.log('a cold profile with no network still fails (the cache is not fabricating hits)',
+      res.ok === false, res.error || res.out);
+  } finally {
+    await cold.close();
+    try { rmSync(coldDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  return r.summary();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().then((s) => process.exit(s.failed > 0 ? 1 : 0));
+}

--- a/desktop/electron/test/security.test.mjs
+++ b/desktop/electron/test/security.test.mjs
@@ -57,6 +57,40 @@ export default async function run() {
     await waitForAppReady(page);
     r.log('can navigate back to the application root', /index\.html$/.test(page.url()), page.url());
 
+    /* ---------------- the application menu ---------------- */
+    //
+    // The shell replaces Electron's default menu, partly for branding (the
+    // default Help links to electronjs.org) but mainly because the menu is the
+    // only place the runtime cache can be inspected or cleared — the app's own
+    // Memory & Storage panel works through the Cache API, which is empty under
+    // app://. Asserted here so the surface cannot quietly disappear.
+    const menu = await shell.electronApp.evaluate(({ Menu }) => {
+      const m = Menu.getApplicationMenu();
+      if (!m) return null;
+      return m.items.map((i) => ({
+        label: i.label,
+        items: (i.submenu ? i.submenu.items : []).map((x) => x.label).filter(Boolean),
+      }));
+    });
+    r.log('an application menu is installed', menu !== null);
+    const labels = (menu || []).map((m) => m.label.replace(/&/g, ''));
+    r.log('the menu is SciREPL\'s, not Electron\'s default',
+      labels.includes('Runtimes'), labels.join(', '));
+
+    const runtimes = (menu || []).find((m) => m.label.replace(/&/g, '') === 'Runtimes');
+    r.log('the runtime cache can be inspected from the menu',
+      !!runtimes && runtimes.items.some((l) => /Downloaded runtimes/i.test(l)),
+      runtimes && runtimes.items.join(' | '));
+    r.log('the runtime cache can be cleared from the menu',
+      !!runtimes && runtimes.items.some((l) => /Clear downloaded runtimes/i.test(l)));
+
+    // Copy/paste accelerators matter in a REPL and are easy to lose when the
+    // default menu is replaced.
+    const edit = (menu || []).find((m) => m.label.replace(/&/g, '') === 'Edit');
+    r.log('Edit still provides cut/copy/paste',
+      !!edit && ['Cut', 'Copy', 'Paste'].every((l) => edit.items.includes(l)),
+      edit && edit.items.join(' | '));
+
     /* ---------------- no remote module ---------------- */
 
     const remote = await shell.electronApp.evaluate(async ({ app }) => {

--- a/desktop/electron/test/security.test.mjs
+++ b/desktop/electron/test/security.test.mjs
@@ -9,15 +9,7 @@
  */
 
 import { launchShell, createReporter, waitForAppReady, attachLogs } from './harness.mjs';
-
-/** Run a snippet through the real JavaScript kernel, as a notebook cell would. */
-async function runNotebookCell(page, code) {
-  return page.evaluate(async (src) => {
-    const km = window.kernelManager;
-    await km.ensureReady('javascript');
-    return await km.execute(src, 'javascript');
-  }, code);
-}
+import { assertBoundary, runNotebookCell } from './probes/security.mjs';
 
 export default async function run() {
   const r = createReporter('security');
@@ -34,193 +26,36 @@ export default async function run() {
     r.log('renderer ran with the OS sandbox enabled', !sandboxRelaxed,
       sandboxRelaxed ? 'SCIREPL_ELECTRON_NO_SANDBOX=1 — result does not attest to OS sandboxing' : '');
 
-    /* ---------------- Node is absent from the renderer ---------------- */
+    /* ------------- the shared renderer/native boundary probes -------------- */
+    //
+    // These live in probes/security.mjs and are run identically against the
+    // packaged build by packaged.test.mjs. One definition of the boundary, so a
+    // packaged app cannot regain Node access while a drifting copy of the
+    // assertions keeps passing here.
+    await assertBoundary(r, page, shell.electronApp);
 
-    const nodeGlobals = await page.evaluate(() => ({
-      require: typeof window.require,
-      process: typeof window.process,
-      Buffer: typeof window.Buffer,
-      module: typeof window.module,
-      exports: typeof window.exports,
-      global: typeof window.global,
-      __dirname: typeof window.__dirname,
-      electron: typeof window.electron,
-      ipcRenderer: typeof window.ipcRenderer,
-    }));
-    for (const [name, type] of Object.entries(nodeGlobals)) {
-      r.log(`renderer global \`${name}\` is undefined`, type === 'undefined', type);
-    }
-
-    /* ------- the same, but executed as a notebook cell (the real threat) ------- */
-
-    const cellProbe = await runNotebookCell(page, `
-      const probe = {};
-      for (const name of ['require','process','Buffer','module','__dirname','global','electron','ipcRenderer']) {
-        try { probe[name] = typeof eval(name); } catch (e) { probe[name] = 'ReferenceError'; }
-      }
-      JSON.stringify(probe)
-    `);
-    let cellGlobals = {};
-    try { cellGlobals = JSON.parse(cellProbe.result?.content || '{}'); } catch { /* leave empty */ }
-    const reachable = Object.entries(cellGlobals).filter(([, v]) => v !== 'undefined' && v !== 'ReferenceError');
-    r.log('notebook cell cannot reach any Node global',
-      reachable.length === 0, JSON.stringify(cellGlobals));
-
-    // The classic escapes.
-    const escapes = await runNotebookCell(page, `
-      const out = {};
-      try { out.processViaCtor = typeof (new Function('return process'))(); } catch (e) { out.processViaCtor = 'blocked:' + e.name; }
-      try { out.requireViaTop = typeof top.require; } catch (e) { out.requireViaTop = 'blocked:' + e.name; }
-      try { out.requireViaParent = typeof parent.require; } catch (e) { out.requireViaParent = 'blocked:' + e.name; }
-      JSON.stringify(out)
-    `);
-    let escapeResult = {};
-    try { escapeResult = JSON.parse(escapes.result?.content || '{}'); } catch { /* leave empty */ }
-    const escaped = Object.entries(escapeResult).filter(([, v]) => v === 'function' || v === 'object');
-    r.log('notebook cell cannot reach Node via Function constructor / top / parent',
-      escaped.length === 0, JSON.stringify(escapeResult));
-
-    /* ---------------- the exposed surface is exactly the allowlist ---------------- */
-
-    const surface = await page.evaluate(() => {
-      const api = window.sciREPLPlatform;
-      if (!api) return null;
-      return {
-        keys: Object.keys(api).sort(),
-        frozen: Object.isFrozen(api),
-        types: Object.fromEntries(Object.keys(api).map(k => [k, typeof api[k]])),
-      };
-    });
-    r.log('preload exposes the platform API', surface !== null, JSON.stringify(surface));
-    r.log('exposed surface is exactly [getAppInfo, getDistributionInfo]',
-      surface && JSON.stringify(surface.keys) === JSON.stringify(['getAppInfo', 'getDistributionInfo']),
-      surface && JSON.stringify(surface.keys));
-    r.log('exposed API object is frozen', surface?.frozen === true);
-
-    // No generic escape hatch of any name.
-    const hatches = await page.evaluate(() => {
-      const api = window.sciREPLPlatform || {};
-      return ['invoke', 'send', 'on', 'ipc', 'ipcRenderer', 'require', 'exec', 'spawn',
-        'readFile', 'writeFile', 'fs', 'shell', 'openPath', 'eval']
-        .filter(k => typeof api[k] !== 'undefined');
-    });
-    r.log('no generic invoke/send/fs/shell escape hatch is exposed',
-      Array.isArray(hatches) && hatches.length === 0, JSON.stringify(hatches));
-
-    /* ---------------- the allowlisted ops are safe and work ---------------- */
-
-    const appInfo = await page.evaluate(() => window.sciREPLPlatform.getAppInfo());
-    r.log('getAppInfo returns build facts only',
-      !!appInfo && typeof appInfo.electronVersion === 'string' && !('cwd' in appInfo) && !('env' in appInfo),
-      JSON.stringify(appInfo));
-
+    // Development-shell specifics, not part of the shared boundary.
     const dist = await page.evaluate(() => window.sciREPLPlatform.getDistributionInfo());
     r.log('getDistributionInfo reports the Free edition',
       dist && dist.edition === 'free' && dist.container === 'electron', JSON.stringify(dist));
-    r.log('no entitlement/licence value is fabricated',
-      dist && dist.store === null, JSON.stringify(dist && dist.store));
+    r.log('an unpackaged run reports itself as unpackaged',
+      dist && dist.packaged === false, String(dist && dist.packaged));
 
-    // Renderer-supplied arguments are inert: the preload wrapper takes no
-    // parameters and forwards none, so nothing the caller passes can reach the
-    // main process or influence the reply. (The main process independently
-    // rejects arguments on the channel — see ipc.unit.test.mjs, which covers
-    // assertNullary directly; that guard matters if the channel is ever reached
-    // by something other than this wrapper.)
-    const argEffect = await page.evaluate(async () => {
-      const plain = await window.sciREPLPlatform.getAppInfo();
-      const withArgs = await window.sciREPLPlatform.getAppInfo('extra', { evil: true }, 42);
-      return { same: JSON.stringify(plain) === JSON.stringify(withArgs), withArgs };
-    });
-    r.log('renderer-supplied arguments to the platform API are inert',
-      argEffect.same === true, JSON.stringify(argEffect.withArgs));
+    /* ------- in-app navigation must still be PERMITTED (regression) ------- */
+    //
+    // assertBoundary already proved off-origin navigation and window.open are
+    // refused. The mirror image needs its own guard: the will-navigate policy
+    // classifies URLs in the main process, where Node reports
+    // `origin === 'null'` for the custom scheme, and an origin-based check
+    // silently blocked the app from navigating within itself.
 
-    /* ---------------- navigation policy ---------------- */
-
-    // A notebook cell trying to navigate the shell to a remote origin.
-    const beforeUrl = page.url();
-    await runNotebookCell(page, `try { window.location.href = 'https://example.com/'; } catch (e) {} ; 1`);
-    await page.waitForTimeout(1500);
-    const afterUrl = page.url();
-    r.log('notebook cell cannot navigate the window off the app origin',
-      afterUrl === beforeUrl, `${beforeUrl} -> ${afterUrl}`);
-
-    // The mirror image, and a regression guard: navigation *within* the app
-    // must still work. The will-navigate policy classifies URLs in the main
-    // process, where Node reports `origin === 'null'` for the custom scheme;
-    // an origin-based check silently blocked all in-app navigation here.
     await page.evaluate(() => { window.location.href = 'privacy.html'; });
     await page.waitForURL(/privacy\.html$/, { timeout: 30_000 }).catch(() => {});
-    const navigatedInApp = page.url();
-    r.log('in-app navigation is permitted', /privacy\.html$/.test(navigatedInApp), navigatedInApp);
+    r.log('in-app navigation is permitted', /privacy\.html$/.test(page.url()), page.url());
 
     await page.goto('app://scirepl/index.html', { waitUntil: 'domcontentloaded', timeout: 120_000 });
     await waitForAppReady(page);
     r.log('can navigate back to the application root', /index\.html$/.test(page.url()), page.url());
-
-    // window.open must never produce a second renderer.
-    const windowCount = await shell.electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
-    await runNotebookCell(page, `try { window.open('https://example.com/'); } catch (e) {}; 1`);
-    await page.waitForTimeout(1500);
-    const windowCountAfter = await shell.electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
-    r.log('window.open does not create a new Electron window',
-      windowCountAfter === windowCount, `${windowCount} -> ${windowCountAfter}`);
-
-    /* ---------------- webPreferences are as declared ---------------- */
-
-    const prefs = await shell.electronApp.evaluate(({ BrowserWindow }) => {
-      const w = BrowserWindow.getAllWindows()[0];
-      const wc = w.webContents;
-      return {
-        // These are the values the main process actually constructed the window with.
-        nodeIntegration: wc.getLastWebPreferences()?.nodeIntegration ?? null,
-        contextIsolation: wc.getLastWebPreferences()?.contextIsolation ?? null,
-        sandbox: wc.getLastWebPreferences()?.sandbox ?? null,
-        webSecurity: wc.getLastWebPreferences()?.webSecurity ?? null,
-        webviewTag: wc.getLastWebPreferences()?.webviewTag ?? null,
-      };
-    });
-    r.log('nodeIntegration is false', prefs.nodeIntegration === false, String(prefs.nodeIntegration));
-    r.log('contextIsolation is true', prefs.contextIsolation === true, String(prefs.contextIsolation));
-    r.log('sandbox is true', prefs.sandbox === true, String(prefs.sandbox));
-    r.log('webSecurity is enabled', prefs.webSecurity !== false, String(prefs.webSecurity));
-    r.log('webviewTag is disabled', prefs.webviewTag === false, String(prefs.webviewTag));
-
-    /* ---------------- known, deliberate PWA divergence: Ko-fi widget ---------------- */
-
-    // www/index.html:407 loads the Ko-fi support widget from storage.ko-fi.com,
-    // which is not on the CSP allowlist (see KOFI_EXCLUSION in protocol.js).
-    // This asserts the divergence is real, contained, and silent — and captures
-    // the actual CSP violation so the check cannot pass vacuously on a machine
-    // that simply has no network.
-    await page.addInitScript(() => {
-      window.__cspViolations = [];
-      document.addEventListener('securitypolicyviolation', (e) => {
-        window.__cspViolations.push({ uri: e.blockedURI, directive: e.effectiveDirective });
-      });
-    });
-    await page.reload({ waitUntil: 'load', timeout: 120_000 });
-    await waitForAppReady(page);
-    await page.waitForTimeout(1500); // let the blocked <script> resolve
-
-    const kofi = await page.evaluate(() => ({
-      widgetGlobal: typeof window.kofiwidget2,
-      violations: window.__cspViolations || [],
-      // Proof that only the widget was lost: the rest of the Help panel is intact.
-      helpPrivacyLink: !!document.getElementById('help-privacy-link'),
-      helpPanel: !!document.getElementById('help-modal') || !!document.querySelector('#help-privacy-link'),
-    }));
-
-    const kofiBlockedByCsp = kofi.violations.some(v => String(v.uri).includes('ko-fi.com'));
-    r.log('the Ko-fi widget origin is blocked by CSP, not merely unreachable',
-      kofiBlockedByCsp, JSON.stringify(kofi.violations));
-    r.log('the Ko-fi widget does not load in the shell (known divergence)',
-      kofi.widgetGlobal === 'undefined', kofi.widgetGlobal);
-    r.log('blocking the widget degrades silently — the rest of Help is intact',
-      kofi.helpPrivacyLink === true, JSON.stringify(kofi));
-
-    const kofiErrors = attachedLogs.filter(l => l.startsWith('[pageerror]') && /ko-?fi/i.test(l));
-    r.log('blocking the widget raises no uncaught page error',
-      kofiErrors.length === 0, kofiErrors.join(' | '));
 
     /* ---------------- no remote module ---------------- */
 

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -432,18 +432,26 @@ file the Android build reads was changed. `npm run build:play` and
 
 ## 8. The shell's own test suite
 
-`npm run test:windows` — **verified, 199 assertions, 0 failures**:
+`npm run test:windows` — **verified, 0 failures**:
 
 | Suite | Result | Needs Electron? |
 | --- | --- | --- |
-| `policy-unit` | 52 passed | no |
+| `policy-unit` | 59 passed | no |
 | `shell-launch` | 18 passed | yes |
-| `security` | 34 passed | yes |
+| `security` | 22 passed | yes |
 | `artifact-boundary` | 14 passed | yes |
 | `download` | 9 passed | yes |
 | `persistence` | 9 passed | yes |
-| `kernels` | 46 passed, 2 known-gap skips | yes |
+| `kernels` | 46 passed, 2 known-gap skips (23 without the browser baseline) | yes |
 | `offline` | 17 passed | yes |
+| `packaged` | 56 passed | yes, **and a built package** — opt-in, see §13 |
+
+Counts shifted in Phase 0.5 and the totals are not comparable to the Phase 0
+figure of 199. `security` fell from 34 to 22 because its checks moved into
+`probes/security.mjs`, where related assertions are graded as a group rather
+than one per Node global — the same ground is covered, by one definition now
+shared with the packaged suite. `policy-unit` rose with the packaged-layout
+path tests.
 
 Export *correctness* is deliberately **not** re-tested — the existing browser
 tests already cover which bytes each format produces, and that logic is
@@ -660,3 +668,120 @@ anything. None is justified by a Phase 0 observation.
 **Recommendation: proceed to Phase 1**, starting with the realm-boundary decision
 (§11.1) rather than with a broad platform-interface refactor. Do not proceed to
 MSIX, Store submission or Pro work until §9 has been executed on real Windows.
+
+---
+
+## 13. Phase 0.5: portable Windows preview
+
+Phase 0 proved the shell works. Phase 0.5 makes it possible to *look at it* on
+Windows without a toolchain — the gap between "CI says it passes" and "someone
+can actually try it".
+
+Two deliverables, both Free-only, neither a release. Running instructions:
+[`WINDOWS_PREVIEW.md`](WINDOWS_PREVIEW.md).
+
+### One-command developer launch
+
+`npm run dev:windows` (`desktop/electron/scripts/dev-windows.mjs`) checks Node
+(>= 22) and the platform, configures the Free profile, fetches the bundled
+runtimes, installs the isolated Electron dependencies, provisions the Electron
+binary, and launches. Completed steps are detected and skipped, so it doubles as
+the everyday start command. It installs nothing system-wide and needs no
+elevation.
+
+Two failure modes it reports rather than stumbles into: a Node older than 22,
+and a checkout on a UNC path (`\\wsl.localhost\…`), which Windows Node tooling
+and Electron handle unreliably. On a non-Windows host it warns instead of
+failing — running under WSLg is a useful look at the UI, but it launches the
+*Linux* Electron build and cannot substitute for Windows verification.
+
+### Unsigned portable preview
+
+`npm run package:windows` (`packaging/build-portable.mjs`, `@electron/packager`
+pinned to `20.2.0`) produces a directory containing a directly launchable
+`SciREPL.exe`. The `Windows portable preview` workflow — `workflow_dispatch`
+only — builds it on `windows-latest`, verifies it, and uploads it as
+`SciREPL-windows-x64-preview-<sha>`. The artifact GitHub produces *is* the
+distributable ZIP: download, extract, run. Measured: **~472 MB unpacked**
+(win32-x64).
+
+**The build is unsigned, so SmartScreen warns on first run.** That is expected
+for an unsigned binary and is documented for testers rather than papered over.
+Signing belongs with Store packaging and is out of scope.
+
+#### Packaged layout, and why it needed a code change
+
+Phase 0's `main.js` derived everything from `__dirname`:
+
+```js
+const REPO_ROOT = path.resolve(__dirname, '..', '..');   // wrong once packaged
+const WWW_ROOT  = path.join(REPO_ROOT, 'www');
+```
+
+In a packaged app `__dirname` is inside `resources/app.asar` and there is no
+repository above it, so both `www/` and the version lookup would have broken —
+silently, as a window that opens and 404s everything. `paths.js` now resolves
+both layouts as pure functions, unit-tested rather than only discoverable by
+launching a build:
+
+```
+SciREPL-win32-x64/
+  SciREPL.exe
+  resources/
+    app.asar          the shell (main, protocol, security, preload, ipc, paths)
+    www/              the application tree — deliberately OUTSIDE the asar
+    build-info.json   version, profile, commit, timestamp
+```
+
+`www/` stays outside the asar because protocol.js serves it with
+`net.fetch(file://…)`, which reads real files and does not go through Electron's
+asar layer. Version and profile come from `build-info.json`, so both survive the
+packaged layout — asserted by the `packaged` suite, not assumed.
+
+### A finding the packaged tests caught
+
+The first build shipped **`www/pro/`** inside the artifact: the Pro landing
+page, its privacy and testing pages, and ~800 kB of Pro branding (app icon and
+Play Store feature graphic). Those files are in the repository so GitHub Pages
+can serve them — nothing in `www/js` links to them and the shell never navigates
+there — but a Free preview must not carry Pro assets to a tester.
+
+They are now filtered out of the staged copy at package time and their absence
+is asserted twice: once by the build script, once by `packaged.test.mjs`.
+
+**The website is unaffected.** `www/pro/**` remains tracked in git and
+`deploy-pages.yml` is unchanged, so the Pro landing page still publishes exactly
+as before. The filter applies only to the copy staged into the `.exe`.
+
+### Packaged verification **[verified]**
+
+`packaged.test.mjs` — 56 assertions, 0 failures — drives the real packaged
+binary with `SCIREPL_WWW` deliberately unset, so the app must find its own
+bundled tree or fail:
+
+| Check | Result |
+| --- | --- |
+| loads `app://scirepl/index.html` from its own resources | ✅ |
+| version and build profile resolve in the packaged layout | ✅ |
+| Node unreachable from a notebook cell (same `probes/security.mjs` as the dev shell) | ✅ |
+| `nodeIntegration` off, `contextIsolation`/`sandbox` on, no escape hatch | ✅ |
+| off-origin navigation and `window.open` refused | ✅ |
+| bundled kernels run — JavaScript, Bash, ClojureScript, SWI-Prolog, Python | ✅ |
+| SharedVFS + localStorage survive a packaged-app restart | ✅ |
+| no Pro material, no bundled R, no build machinery in the artifact | ✅ |
+
+Reuse is the point: the boundary is defined once in `probes/security.mjs` and
+applied to both the development shell and the package. A packaged build that
+quietly regained Node access while a separate copy of the assertions kept
+passing is the failure this arrangement is designed to prevent.
+
+Verified on Linux (`SciREPL-linux-x64`) locally and on `windows-latest` in the
+preview workflow. The Windows executable cannot be executed from this
+development environment, so the win32 build is verified by CI, not by hand here.
+
+### Still out of scope
+
+MSIX, Store submission, code signing, auto-update, entitlement or licence
+checking, Pro anything. Unchanged from §9: the manual Windows checks — display
+scaling, native dialogs, accessibility, sleep/resume, non-ASCII profile paths —
+are exactly what the portable preview now makes it practical for a human to do.

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -346,6 +346,72 @@ something else is quietly serving the bytes.
 This also removes the argument for bundling R into a Windows build: offline R no
 longer costs 50 MB of download, so the Free/Pro profile difference stays intact.
 
+#### Root cause: the service worker registers, then dies during install
+
+Traced properly, rather than inferred from the `addAll` error alone:
+
+```
+navigator.serviceWorker.register('sw.js')  ->  succeeds, scope app://scirepl/
+after 4s: installing=false waiting=false active=false   ->  never activates
+caches.open(c).put(httpsRequest, response) ->  WORKS from an app:// page
+caches.open(c).add('index.html')           ->  throws: scheme 'app' unsupported
+```
+
+So the chain is: `sw.js`'s `install` calls `addAll(APP_SHELL)` on `app://` URLs,
+which rejects; `event.waitUntil` therefore rejects; the worker never reaches
+*activated*; its `fetch` handler never runs; and `CDN_CACHE` is never written.
+
+The important part is the third line. **Caching `https` requests from an
+`app://` page works.** The CDN cache mechanism is not the thing that is broken —
+only the app-shell precache is, and it takes the whole worker down with it.
+
+That also means this is a robustness bug beyond the shell: today a single
+unreachable entry in `APP_SHELL` fails the entire install on *any* platform,
+silently disabling offline support for the PWA and Android too.
+
+#### Consistency with Android — an open decision
+
+This matters because the mobile build sets the expected behaviour, and the two
+available fixes do not agree on it.
+
+| | Android / PWA today | Shell with `runtime-cache.js` | Shell if `sw.js` install were tolerant |
+| --- | --- | --- | --- |
+| Reload App keeps runtimes | ✅ | ✅ | ✅ |
+| **Memory → Clear Cache** removes them | ✅ | ❌ clears two empty caches and reports success | ✅ |
+| **Per-runtime Clear Cache** button | ✅ appears | ❌ never appears | ✅ |
+| Storage figure includes them | ✅ | ❌ reports 0 B | ✅ |
+| R works offline after one use | untested | ✅ | likely partial — see below |
+
+`runtime-cache.js` delivers offline R, but through a cache the application's own
+**Memory & Storage** panel cannot see or clear, because that panel works through
+the Cache API. Measured: after loading Lua, the panel reports `0 B`, "Clear
+Cache" leaves the bytes on disk, and the per-runtime button does not appear. The
+shell therefore adds a management surface it owns (`menu.js` → **Runtimes**),
+but that is a *different* surface from the one mobile users learn — which is
+exactly the divergence to avoid.
+
+The mobile-consistent fix is to make `sw.js`'s install tolerate a failed
+app-shell precache, so the worker activates and populates `CDN_CACHE` exactly as
+it does on Android. Every existing affordance then works identically on both
+platforms with no shell-specific UI at all.
+
+Two caveats before doing it:
+
+- It is a change to shared `www/` code, which this work has deliberately not
+  touched, and it needs re-testing on Android and the PWA.
+- It may not fully replace `runtime-cache.js` for R. webR probes its virtual
+  filesystem with `HEAD`, and the service worker only caches `GET`
+  (`sw.js:155`), so R may still fail offline under the service worker alone.
+  Whether R currently works offline **on Android** is untested and worth
+  measuring first — if it does not, then the shell would be *ahead* of mobile
+  rather than inconsistent with it, which is a different conversation.
+
+**Recommendation:** measure Android's offline-R behaviour, then fix `sw.js`
+install tolerance in the shared phase and re-evaluate whether the main-process
+cache is still earning its place. Until that decision is made, the shell's cache
+stays behind `SCIREPL_RUNTIME_CACHE` (set it to `0` to get the pre-fix
+behaviour) and its management lives in the application menu.
+
 #### The consent prompt is a setting, not a defect
 
 An earlier draft of this report called the recurring download prompt a papercut

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -300,9 +300,32 @@ It is:
   not retain a payload that size and the explicit cache that would have is
   broken.
 
-One secondary consequence remains regardless of size: nothing here is
-guaranteed. The HTTP cache is heuristic and evictable, so it is a weaker promise
-than an explicit cache, not a replacement for one.
+Raising Chromium's disk cache does **not** rescue R: re-measured with
+`--disk-cache-size=2147483648` (2 GB) and it still times out offline. So this is
+not a cache-size limit, and tuning the engine will not fix it. webR fetches its
+runtime through Emscripten's own filesystem layer, which does not settle into
+the HTTP cache the way a single script file does.
+
+One further caveat regardless of size: nothing here is guaranteed. The HTTP
+cache is heuristic and evictable, so it is a weaker promise than an explicit
+cache, not a replacement for one.
+
+#### Can R be made to work offline? Yes — but not by caching
+
+Worth stating plainly, because "R is not cached" reads as "R cannot work
+offline", and that is not the case:
+
+| Approach | Works? | Notes |
+| --- | --- | --- |
+| Service worker `CDN_CACHE` | ❌ never | Cache API rejects the `app://` scheme outright. Not tunable. |
+| Chromium HTTP disk cache | ❌ | Fails at default size and at 2 GB. Not a size problem. |
+| **Bundle R in the profile** | ✅ | Already implemented — this is exactly what the `pro` profile does (`build-profiles.json`). ~50 MB added to the download. |
+| **Shell-side runtime download** | ✅ likely | Fetch webR once into `userData` and serve it from `app://`. Gives offline R without inflating the initial download. **Not implemented or tested** — proposed for Phase 1/2. |
+
+So offline R is a solved problem technically; the open question is which
+solution, and bundling it into a *Free* build would remove what currently
+distinguishes `full` from `pro`. That makes it a product decision rather than an
+engineering one.
 
 #### The consent prompt is a setting, not a defect
 

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -1044,6 +1044,37 @@ AppImage, `.deb`, or Flatpak. That is the right shape for a Linux *release
 asset* and is proposed as the next piece of work, not bodged into the portable
 preview.
 
+### A real advantage over Android: DevTools
+
+**[verified]** The packaged build opens Chromium DevTools from **View → Toggle
+Developer Tools** (or F12). On Android, inspecting the same application means
+`chrome://inspect`, USB debugging and a second machine; here it is one keystroke,
+against the identical `www/` code.
+
+That makes the desktop build the most convenient place to debug notebooks,
+inspect SharedVFS and IndexedDB, and see CSP violations — the Ko-fi block in §5
+is visible in the console exactly as it would be in a browser.
+
+It costs nothing in security, which is asserted rather than assumed. With
+DevTools open in the packaged app:
+
+```
+require = undefined   process = undefined   new Function('return process') = blocked
+window.sciREPLPlatform = [getAppInfo, getDistributionInfo]
+```
+
+The boundary is `contextIsolation` + `sandbox` + `nodeIntegration: false`, and
+those apply to whoever is typing. A user at the DevTools console has exactly what
+a notebook cell has — so this is parity with pressing F12 on the PWA, not an
+escalation. `packaged.test.mjs` asserts both halves: that DevTools still opens
+once packaged, and that opening it widens nothing.
+
+Worth noting for a future Pro build: DevTools does let a user read the bundled
+application code. That is not a new exposure — `app.asar` can be unpacked
+regardless, and the proposal is already explicit that packaging is not DRM. It
+is a reason to keep entitlement logic in the main process, which is where it
+already belongs.
+
 ### Out of scope: the `[WARN: COPY MODE]` title prefix
 
 Not ours. The string appears nowhere in the WSLg logs (`weston.log`,

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -300,15 +300,36 @@ It is:
   not retain a payload that size and the explicit cache that would have is
   broken.
 
-Two secondary consequences remain regardless of size:
+One secondary consequence remains regardless of size: nothing here is
+guaranteed. The HTTP cache is heuristic and evictable, so it is a weaker promise
+than an explicit cache, not a replacement for one.
 
-- The "cached" branch of the download-consent check
-  (`kernel_manager.js:190-202`) asks the **Cache API**, which is always empty
-  here. So the consent modal reappears for CDN kernels every session even when
-  the fetch will be served instantly from the HTTP cache. Cosmetic, but it is
-  what made the first kernel matrix in this spike look like a hang (§5).
-- Nothing is guaranteed. The HTTP cache is heuristic and evictable, so this is a
-  weaker promise than an explicit cache, not a replacement for one.
+#### The consent prompt is a setting, not a defect
+
+An earlier draft of this report called the recurring download prompt a papercut
+needing a shared-code fix. That was wrong on both counts.
+
+The prompts are deliberate consent gates, both persisted, and both already
+under user control — in shared `www/` code, so the behaviour is **identical on
+Android, the PWA and the shell**:
+
+| Prompt | Where the decision is stored | How to stop being asked |
+| --- | --- | --- |
+| Privacy notice | `scirepl_privacy_accepted` | Accepted once, then never shown again (`kernel_manager.js:134`). Revocable from Settings. |
+| Runtime download | `scirepl_auto_download` | Settings → **Runtime Downloads** → *Auto-download runtimes (skip confirmation)* (`www/index.html`, handled at `file_io.js:163`). |
+
+With auto-download enabled, `kernel_manager.js:202` skips the confirmation
+outright, so the inert Cache API never enters into it.
+
+The genuine Electron-specific nuance is narrow: for a user who has *not*
+enabled that setting, the `cached` shortcut in the same line never fires here,
+because it asks the Cache API. On Android and the PWA the service worker cache
+works, so after the first download the prompt is skipped automatically. In the
+shell it is asked each session even when the bytes then arrive instantly from
+the HTTP cache. One checkbox removes the difference.
+
+This is also what made the first kernel matrix in this spike look like a hang —
+the test harness had not granted the consent the browser tests grant.
 
 Not worked around in Phase 0. The platform-appropriate fix is for a packaged
 desktop application to **bundle** its runtimes rather than cache CDN downloads —
@@ -581,7 +602,7 @@ Risks, in the order they should be addressed:
 | 7 | **CDN download-consent modal on a packaged app.** | Low | Product decision (§5). |
 | 8 | **TypR output gap.** | Low | Pre-existing, reproduces in browser, unrelated to Windows. |
 | 9 | **Ko-fi widget blocked in the shell** (§5). | Low | Deliberate; degrades silently; pinned by tests. Resolve with a shared plain-link change (§11.5), not a CSP exception. |
-| 10 | **Service worker cache inert under `app://`** (§5). Chromium's HTTP cache covers small CDN runtimes (Lua works offline after one use) but not large ones (R does not). The consent modal also reappears every session. | Low-Medium | Bundle Lua in the Windows profile; R is a Free/Pro product decision. |
+| 10 | **Service worker cache inert under `app://`** (§5). Chromium's HTTP cache covers small CDN runtimes (Lua works offline after one use) but not large ones (R does not). | Low | Bundle Lua in the Windows profile; R is a Free/Pro product decision. The consent prompt is an existing user setting, not a defect. |
 
 ---
 
@@ -663,10 +684,8 @@ with no downside. Bundling R offline is what currently distinguishes the `pro`
 profile from `full`, so doing it in a Free Windows build is a pricing decision
 rather than an engineering one — flagged, not assumed.
 
-Separately, the consent modal reappears every session for CDN kernels because
-the cached-check asks the broken Cache API. Fixing that means touching
-`kernel_manager.js`, which is shared with the PWA and Android, so it belongs in
-the shared-code phase rather than the shell.
+No change is needed for the consent prompt: it is a designed, persisted setting
+that already exists on all three platforms (§5). Nothing to fix there.
 
 **7. Keep the artifact boundary test in CI.** It already fails the build if Pro
 content, a hardcoded `isPro`, a Store licence call, or commerce code appears in

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -277,30 +277,44 @@ sw.js:97  Uncaught (in promise) TypeError:
 ```
 
 The Cache API only accepts `http`/`https` requests, so `www/sw.js`'s app-shell
-precache (`CACHE_VERSION` / `APP_CACHE`) and its CDN runtime cache
-(`CDN_CACHE`) are both non-functional in the shell.
+precache (`APP_CACHE`) and its CDN runtime cache (`CDN_CACHE`) are both
+non-functional. Measured after a session that loaded a CDN kernel: both caches
+exist and both contain **0 entries**.
 
-Impact is smaller than it looks, and the measured results already reflect it:
+The practical impact is narrower than that sounds, and was initially overstated
+in this report. Chromium's ordinary **HTTP disk cache** still works for
+cross-origin fetches, and it covers much of what the service worker would have.
+Measured across a real restart with the same profile and the network then cut:
 
-- **App shell** — unaffected in practice. Every local asset is served by the
-  `app://` protocol handler straight off disk, so the precache was redundant
-  here. The offline suite confirms the app starts, reloads and runs its bundled
-  kernels with the network cut **[verified]**.
-- **CDN kernels** — this is the real cost. In the PWA, `CDN_CACHE` is what lets
-  Lua and R work offline after one online use. In the shell they cannot be
-  cached at all, so they need the network every session. That is consistent
-  with, and part of the explanation for, the offline result already reported
-  above (Lua fails cleanly offline).
+| Runtime | Size | Offline after one online use |
+| --- | --- | --- |
+| App shell (HTML/CSS/JS/WASM) | — | ✅ served from `app://` off disk; the precache was redundant here |
+| **Lua / Fengari** | ~200 kB | ✅ **works** — retained by the HTTP cache |
+| **R / webR** | ~50 MB | ❌ **fails** — too large to survive; times out offline |
 
-It also means the "cached" branch of the download-consent check in
-`kernel_manager.js:190-202` never sees a hit under `app://`, so the consent
-modal reappears for CDN kernels every session.
+So the correct statement is *not* "CDN kernels need the network every session".
+It is:
 
-Not a blocker, and deliberately not worked around in Phase 0. The proper fix is
-a platform-appropriate one: a packaged desktop app should bundle its runtimes
-rather than cache CDN downloads — i.e. Windows builds should use a profile that
-bundles Lua and R offline, which is exactly what the existing `pro` profile
-already does for R. Recorded for Phase 2 profile selection (§11).
+- **Lua** works offline after one online use, like the PWA.
+- **R** does not. It needs the network every session, because the HTTP cache does
+  not retain a payload that size and the explicit cache that would have is
+  broken.
+
+Two secondary consequences remain regardless of size:
+
+- The "cached" branch of the download-consent check
+  (`kernel_manager.js:190-202`) asks the **Cache API**, which is always empty
+  here. So the consent modal reappears for CDN kernels every session even when
+  the fetch will be served instantly from the HTTP cache. Cosmetic, but it is
+  what made the first kernel matrix in this spike look like a hang (§5).
+- Nothing is guaranteed. The HTTP cache is heuristic and evictable, so this is a
+  weaker promise than an explicit cache, not a replacement for one.
+
+Not worked around in Phase 0. The platform-appropriate fix is for a packaged
+desktop application to **bundle** its runtimes rather than cache CDN downloads —
+see §11. Lua is ~200 kB and could simply be bundled; R is the profile difference
+that distinguishes Free from Pro, so bundling it in a Free build is a product
+decision, not a technical one.
 
 ### Known divergence from the PWA: the Ko-fi support widget
 
@@ -567,7 +581,7 @@ Risks, in the order they should be addressed:
 | 7 | **CDN download-consent modal on a packaged app.** | Low | Product decision (§5). |
 | 8 | **TypR output gap.** | Low | Pre-existing, reproduces in browser, unrelated to Windows. |
 | 9 | **Ko-fi widget blocked in the shell** (§5). | Low | Deliberate; degrades silently; pinned by tests. Resolve with a shared plain-link change (§11.5), not a CSP exception. |
-| 10 | **Service worker cache inert under `app://`** (§5) — CDN kernels cannot be cached for offline use. | Medium | Fix by bundling runtimes in the Windows profile rather than relying on web caches, which is the right shape for a packaged app anyway. |
+| 10 | **Service worker cache inert under `app://`** (§5). Chromium's HTTP cache covers small CDN runtimes (Lua works offline after one use) but not large ones (R does not). The consent modal also reappears every session. | Low-Medium | Bundle Lua in the Windows profile; R is a Free/Pro product decision. |
 
 ---
 
@@ -641,12 +655,18 @@ the shell, removes a third-party script from the PWA and Android builds too, and
 needs no CSP exception on any platform. Listed here rather than done in this PR
 because it touches shared `www/` code, which the spike deliberately leaves alone.
 
-**6. Choose a Windows build profile that bundles its runtimes.** The service
-worker cache is inert under `app://` (§5), so a Windows build cannot rely on
-caching CDN downloads for offline use. A packaged desktop application should
-bundle what it needs anyway: define a `windows-free` profile that additionally
-bundles Lua (and, for Pro, R) rather than leaving them on a CDN. This is a
-`build-profiles.json` change, not application code.
+**6. Bundle Lua in a Windows profile; treat R as a product decision.** The
+service worker cache is inert under `app://` (§5). Measurement shows Chromium's
+HTTP cache covers Lua (~200 kB) but not R (~50 MB), so only R actually needs the
+network every session. Bundling Lua is a one-line `build-profiles.json` change
+with no downside. Bundling R offline is what currently distinguishes the `pro`
+profile from `full`, so doing it in a Free Windows build is a pricing decision
+rather than an engineering one — flagged, not assumed.
+
+Separately, the consent modal reappears every session for CDN kernels because
+the cached-check asks the broken Cache API. Fixing that means touching
+`kernel_manager.js`, which is shared with the PWA and Android, so it belongs in
+the shared-code phase rather than the shell.
 
 **7. Keep the artifact boundary test in CI.** It already fails the build if Pro
 content, a hardcoded `isPro`, a Store licence call, or commerce code appears in

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -775,9 +775,22 @@ applied to both the development shell and the package. A packaged build that
 quietly regained Node access while a separate copy of the assertions kept
 passing is the failure this arrangement is designed to prevent.
 
-Verified on Linux (`SciREPL-linux-x64`) locally and on `windows-latest` in the
-preview workflow. The Windows executable cannot be executed from this
-development environment, so the win32 build is verified by CI, not by hand here.
+**Verified on native Windows.** The `win32-x64` build was executed on Windows
+11 via WSL interop — `SciREPL.exe` launched, resolved its own bundled tree at
+`C:\…\resources\www`, loaded `app://scirepl/index.html`, and passed all 56
+assertions with `platform: "win32"` in the reported app info:
+
+```
+SCIREPL_SMOKE_READY electron=43.3.0 chrome=150.0.7871.212 www=C:\Users\…\resources\www
+SCIREPL_SMOKE_OK    url=app://scirepl/index.html
+packaged: 56 passed, 0 failed, 0 skipped
+```
+
+Also verified on Linux (`SciREPL-linux-x64`). The preview workflow re-runs the
+same suite on `windows-latest`.
+
+Measured on Windows: Bash 64 ms init, ClojureScript 49 ms, SWI-Prolog 669 ms,
+Pyodide 6716 ms — all slightly faster than the Linux/WSL figures in §6.
 
 ### Still out of scope
 

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -290,15 +290,10 @@ Measured across a real restart with the same profile and the network then cut:
 | --- | --- | --- |
 | App shell (HTML/CSS/JS/WASM) | — | ✅ served from `app://` off disk; the precache was redundant here |
 | **Lua / Fengari** | ~200 kB | ✅ **works** — retained by the HTTP cache |
-| **R / webR** | ~50 MB | ❌ **fails** — too large to survive; times out offline |
+| **R / webR** | ~50 MB | ❌ **failed** — too large to survive (fixed below by the shell's own cache) |
 
-So the correct statement is *not* "CDN kernels need the network every session".
-It is:
-
-- **Lua** works offline after one online use, like the PWA.
-- **R** does not. It needs the network every session, because the HTTP cache does
-  not retain a payload that size and the explicit cache that would have is
-  broken.
+That was the position before the fix below. With the shell's own cache in place,
+**both** Lua and R work offline after one online use.
 
 Raising Chromium's disk cache does **not** rescue R: re-measured with
 `--disk-cache-size=2147483648` (2 GB) and it still times out offline. So this is
@@ -310,22 +305,46 @@ One further caveat regardless of size: nothing here is guaranteed. The HTTP
 cache is heuristic and evictable, so it is a weaker promise than an explicit
 cache, not a replacement for one.
 
-#### Can R be made to work offline? Yes — but not by caching
+#### Fixed: the shell keeps its own cache in the data directory
 
-Worth stating plainly, because "R is not cached" reads as "R cannot work
-offline", and that is not the case:
+**[verified]** Rather than work around the inert Cache API, the shell now keeps
+the cache the service worker cannot: `desktop/electron/runtime-cache.js`
+intercepts `https` for an allowlist of runtime hosts and stores responses in
+`userData/runtime-cache/`. That directory is the application's own storage —
+not evictable by Chromium, not size-limited, and it survives restarts and
+updates.
 
-| Approach | Works? | Notes |
+Measured, fetch once online then restart with the network cut:
+
+| Runtime | Before | After |
 | --- | --- | --- |
-| Service worker `CDN_CACHE` | ❌ never | Cache API rejects the `app://` scheme outright. Not tunable. |
-| Chromium HTTP disk cache | ❌ | Fails at default size and at 2 GB. Not a size problem. |
-| **Bundle R in the profile** | ✅ | Already implemented — this is exactly what the `pro` profile does (`build-profiles.json`). ~50 MB added to the download. |
-| **Shell-side runtime download** | ✅ likely | Fetch webR once into `userData` and serve it from `app://`. Gives offline R without inflating the initial download. **Not implemented or tested** — proposed for Phase 1/2. |
+| Lua / Fengari (~200 kB) | worked, but only by luck of the HTTP cache | ✅ 0.2 MB cached, runs offline |
+| **R / webR (~50 MB)** | ❌ timed out after 86 s | ✅ **22.6 MB cached, runs offline in ~1 s** |
 
-So offline R is a solved problem technically; the open question is which
-solution, and bundling it into a *Free* build would remove what currently
-distinguishes `full` from `pro`. That makes it a product decision rather than an
-engineering one.
+Two details were needed to make webR work, and both are the kind only
+measurement finds:
+
+- **`HEAD` requests.** webR probes its virtual filesystem with `HEAD` before
+  fetching with `GET`. Caching only `GET` left every probe going to the network,
+  so R still failed offline even with 22 MB cached. The cache key includes the
+  method.
+- **`404` responses.** webR probes for optional files. A probe that *errors*
+  offline behaves differently from one that answers "not found", so 404s are
+  cached too. Safe here because these hosts serve version-pinned immutable
+  paths.
+
+Deliberately narrow: only allowlisted runtime hosts are touched, everything else
+passes through untouched; only `GET`/`HEAD`, never a range request (a partial
+body stored as if whole is a corrupt entry); only `200` and `404`. It is
+main-process only and exposes nothing to the renderer, so the boundary in §4 is
+unchanged. `SCIREPL_RUNTIME_CACHE=0` disables it.
+
+Guarded by `runtime-cache.test.mjs`, which includes a cold-profile check that a
+run which never went online still fails — so the suite cannot pass because
+something else is quietly serving the bytes.
+
+This also removes the argument for bundling R into a Windows build: offline R no
+longer costs 50 MB of download, so the Free/Pro profile difference stays intact.
 
 #### The consent prompt is a setting, not a defect
 
@@ -625,7 +644,7 @@ Risks, in the order they should be addressed:
 | 7 | **CDN download-consent modal on a packaged app.** | Low | Product decision (§5). |
 | 8 | **TypR output gap.** | Low | Pre-existing, reproduces in browser, unrelated to Windows. |
 | 9 | **Ko-fi widget blocked in the shell** (§5). | Low | Deliberate; degrades silently; pinned by tests. Resolve with a shared plain-link change (§11.5), not a CSP exception. |
-| 10 | **Service worker cache inert under `app://`** (§5). Chromium's HTTP cache covers small CDN runtimes (Lua works offline after one use) but not large ones (R does not). | Low | Bundle Lua in the Windows profile; R is a Free/Pro product decision. The consent prompt is an existing user setting, not a defect. |
+| 10 | ~~Service worker cache inert under `app://`~~ — **resolved** (§5). The shell keeps its own cache in `userData`; Lua and R both work offline after one online use. | Resolved | Guarded by `runtime-cache.test.mjs`. |
 
 ---
 
@@ -699,13 +718,12 @@ the shell, removes a third-party script from the PWA and Android builds too, and
 needs no CSP exception on any platform. Listed here rather than done in this PR
 because it touches shared `www/` code, which the spike deliberately leaves alone.
 
-**6. Bundle Lua in a Windows profile; treat R as a product decision.** The
-service worker cache is inert under `app://` (§5). Measurement shows Chromium's
-HTTP cache covers Lua (~200 kB) but not R (~50 MB), so only R actually needs the
-network every session. Bundling Lua is a one-line `build-profiles.json` change
-with no downside. Bundling R offline is what currently distinguishes the `pro`
-profile from `full`, so doing it in a Free Windows build is a pricing decision
-rather than an engineering one — flagged, not assumed.
+**6. ~~Bundle runtimes to work around the inert cache~~ — done differently, and
+already resolved.** The shell now keeps its own cache in `userData`
+(`runtime-cache.js`, §5), so Lua and R both work offline after one online use
+without bundling either. That leaves the Free/Pro profile difference intact and
+avoids adding ~50 MB to the download, which is a better outcome than the
+bundling this item originally proposed. Nothing left to do here.
 
 No change is needed for the consent prompt: it is a designed, persisted setting
 that already exists on all three platforms (§5). Nothing to fix there.

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -339,6 +339,25 @@ body stored as if whole is a corrupt entry); only `200` and `404`. It is
 main-process only and exposes nothing to the renderer, so the boundary in §4 is
 unchanged. `SCIREPL_RUNTIME_CACHE=0` disables it.
 
+**What is deliberately not cached.** `repo.r-wasm.org` is a *mutable* package
+repository: its `PACKAGES` indexes describe what exists right now. Keeping those
+forever would freeze the catalogue at whatever it was on the day a user first
+installed something — `install.packages()` would keep offering stale versions,
+and a future update checker would read a permanent snapshot and report "up to
+date" indefinitely. So the policy splits:
+
+| Request | Cached? |
+| --- | --- |
+| version-pinned assets (`/v0.5.4/…`, `name@1.2.3/…`, `ggplot2_3.5.1.tgz`) | yes, indefinitely |
+| `PACKAGES`, `PACKAGES.gz/.rds/.json`, anything with a query string | **never** |
+| `404` on a version-pinned path | yes — permanently true, and webR's `HEAD` probes need it offline |
+| `404` on a mutable path | **never** — absent today may exist tomorrow |
+
+Consequence: installing *new* R packages still needs a network connection, by
+design. Offline, the honest answer is "not checked", not a stale "up to date".
+The follow-up feature that depends on this is sketched in
+[`proposal-package-update-checks.md`](proposal-package-update-checks.md).
+
 Guarded by `runtime-cache.test.mjs`, which includes a cold-profile check that a
 run which never went online still fails — so the suite cannot pass because
 something else is quietly serving the bytes.
@@ -1074,6 +1093,26 @@ application code. That is not a new exposure — `app.asar` can be unpacked
 regardless, and the proposal is already explicit that packaging is not DRM. It
 is a reason to keep entitlement logic in the main process, which is where it
 already belongs.
+
+### Linux test hosts: `xdg-open` blocks graceful shutdown
+
+**[verified]** On Linux, `shell.openExternal()` shells out to `xdg-open`, which
+hands the URL to a desktop helper and keeps the application alive. Measured on
+WSLg: a single external-link probe made graceful shutdown time out at 20 s,
+while the identical run without one closed in **0.1 s**.
+
+This is a property of the host's URL handler, not of the shell — the same suite
+shuts down cleanly on the Windows CI runner, where `openExternal` returns
+immediately. It presented as a phantom "the packaged app shuts down gracefully"
+failure that survived a clean machine, and was only pinned down by bisecting the
+suite: DevTools alone closed in 0 s, all five kernels loaded closed in 0.1 s, and
+one `window.open` to an external URL reproduced it every time.
+
+The test harness now puts a no-op `xdg-open` first on `PATH` for Linux runs. The
+policy under test is untouched — `setWindowOpenHandler` still denies the window
+and still calls `openExternal` — only the hand-off to the desktop is stubbed.
+Worth knowing before anyone runs this suite on a Linux desktop and concludes the
+shell has a shutdown bug.
 
 ### Out of scope: the `[WARN: COPY MODE]` title prefix
 

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -987,3 +987,67 @@ MSIX, Store submission, code signing, auto-update, entitlement or licence
 checking, Pro anything. Unchanged from §9: the manual Windows checks — display
 scaling, native dialogs, accessibility, sleep/resume, non-ASCII profile paths —
 are exactly what the portable preview now makes it practical for a human to do.
+
+
+---
+
+## 14. Desktop-environment integration (Linux, WSLg)
+
+Findings from running the Linux preview under WSLg, which is worth recording
+because a Linux build is a candidate release asset alongside Windows.
+
+### Fixed: a window that existed but could never be shown
+
+**[verified]** `ready-to-show` **does not fire under WSLg**:
+
+```
+[scirepl] showing window via did-finish-load — ready-to-show did not fire
+```
+
+The window was created hidden and shown on `ready-to-show`, which avoids a white
+flash. When that event never arrives, the result is a window that exists and owns
+a task-bar entry but can never be raised, because it is still hidden — clicking
+the icon does nothing. That is precisely how it presented.
+
+`main.js` now shows the window on the first of `ready-to-show`,
+`did-finish-load`, `did-fail-load`, or a 10-second timeout, and logs which one
+won. Cosmetic polish lost the argument to always being reachable.
+
+Related and self-inflicted: several orphaned Electron processes from killed test
+runs were also sitting in the task bar in exactly this state. They have been
+cleaned up, and the fallback means a future orphan would at least be visible.
+
+### Not fixed: task-bar label and icon
+
+**[verified negative]** The Linux build registers with WSLg as:
+
+```
+appId: scirepl-desktop-electron    appIcon: (nil)
+```
+
+so the entry is labelled with the package directory name and, having no icon,
+renders as a generic penguin. Two attempts, both measured and both ineffective:
+
+| Attempt | Result |
+| --- | --- |
+| `app.setName('SciREPL')` | no change to `appId` |
+| `app.commandLine.appendSwitch('class', 'SciREPL')` | no change to `appId` |
+
+The switch was removed rather than left in place looking like it worked. The
+identity actually comes from the `name` field of the package.json inside
+`app.asar`, and the icon is resolved by matching that identity against an
+**installed `.desktop` file** — which a portable directory does not have.
+
+Fixing it properly means producing a real Linux package rather than a folder:
+a `.desktop` file, an installed icon, and a defined install location — i.e. an
+AppImage, `.deb`, or Flatpak. That is the right shape for a Linux *release
+asset* and is proposed as the next piece of work, not bodged into the portable
+preview.
+
+### Out of scope: the `[WARN: COPY MODE]` title prefix
+
+Not ours. The string appears nowhere in the WSLg logs (`weston.log`,
+`wlog.log`, `stderr.log`), so it originates on the Windows side of WSLg's
+RDP/RAIL integration, and the same prefix appears on unrelated applications
+(Palemoon) on the same machine. WSLg here is 1.0.73.2. `wsl --shutdown` and
+restart is the usual remedy for WSLg window-management oddities.

--- a/docs/WINDOWS_ELECTRON_SPIKE.md
+++ b/docs/WINDOWS_ELECTRON_SPIKE.md
@@ -624,9 +624,15 @@ Everything else keeps its working browser path until evidence says otherwise.
 with a correct default filename, rather than Electron's default dialog behaviour
 (§9 item 4).
 
-**4. Migrate `export.js:1143` (`PdfGenerator`) last.** It is the one call site
-with a materially different desktop implementation, and it needs the Windows
-print verification from §9 first.
+**4. Add `printOrExportPdf`, backed by `webContents.printToPDF()`.** Promoted
+from "last, and only after verification" to a first-class item, because the
+verification happened (§13): the browser fallback opens the *native Windows
+printer dialog*, so exporting a PDF means picking "Microsoft Print to PDF" from
+a printer list. It works, but it is a worse flow than the PWA's Save-as-PDF and
+gives no control over the filename. `printToPDF()` returns bytes directly, so
+the Electron adapter can write a file through a normal Save dialog — aligning
+desktop with what Android already does via the Capacitor `PdfGenerator` plugin
+(`export.js:1143`). This is now the best-evidenced of the platform operations.
 
 **5. Replace the Ko-fi widget with a plain external link** (§5). A one-line
 change in `www/index.html`: swap the third-party `<script>` for a
@@ -791,6 +797,43 @@ same suite on `windows-latest`.
 
 Measured on Windows: Bash 64 ms init, ClojureScript 49 ms, SWI-Prolog 669 ms,
 Pyodide 6716 ms — all slightly faster than the Linux/WSL figures in §6.
+
+### Manual verification on Windows (in progress)
+
+First hands-on session with the packaged preview on Windows 11. Confirmed by a
+human, not by CI:
+
+| Check | Result |
+| --- | --- |
+| `SciREPL.exe` starts from an extracted folder | ✅ |
+| **Package/workbook installation** — the family-tree workbook installed from Browse Packages | ✅ |
+| **PDF export** reaches the Windows print dialog; "Microsoft Print to PDF" selectable | ✅ reached; output fidelity not yet confirmed |
+
+The workbook install is worth calling out: it is a live fetch from GitHub
+releases, so it exercises the CSP `connect-src` allowlist, the package catalog
+and archive extraction inside the packaged origin — an end-to-end path CI does
+not cover.
+
+#### Divergence: PDF export opens the Windows print dialog
+
+`ExportManager.exportPDF` falls back to `iframe.contentWindow.print()`
+(`www/js/export.js:1189`) when the Capacitor PDF plugin is absent, which is the
+case here. In Chrome that call opens Chrome's own print preview, where
+**Save as PDF** is a built-in destination. In Electron it opens the **native
+Windows print dialog** instead, so the user must pick "Microsoft Print to PDF"
+from a printer list.
+
+It works, and "Microsoft Print to PDF" is present on all supported Windows
+versions, so nothing is blocked. But it is a worse flow than the PWA's: an extra
+selection step, a printer-shaped mental model for what is really a file export,
+and no control over the default filename.
+
+This is the strongest concrete argument yet for the `printOrExportPdf` operation
+sketched in the proposal. Electron's `webContents.printToPDF()` returns PDF
+bytes directly, so the Electron adapter could produce a file and show a normal
+Save dialog with a sensible name — matching what Android already does through
+the Capacitor plugin, and better than the browser fallback on both. Added to
+§11 as a Phase 1 item with evidence behind it rather than as a hypothetical.
 
 ### Still out of scope
 

--- a/docs/WINDOWS_PREVIEW.md
+++ b/docs/WINDOWS_PREVIEW.md
@@ -72,10 +72,17 @@ Needs a network connection **every session**:
 - **R/webR** (~50 MB) is too large for the HTTP cache to retain, and the cache
   that would have held it is the broken one. Expect it to download each session.
 
-Either way you will see the **download prompt every session**, even when the
-files come straight from cache: the app checks the (empty) service-worker cache
-to decide whether to ask. Cosmetic — click through it and the load is instant if
-it was cached. See [`WINDOWS_ELECTRON_SPIKE.md`](WINDOWS_ELECTRON_SPIKE.md) §5.
+If you would rather not be asked before each runtime download, turn on
+**Settings → Runtime Downloads → "Auto-download runtimes (skip confirmation)"**.
+The choice is saved, and it works the same here as on Android and the PWA.
+
+Leave it off and the shell will ask each session, even when the files then load
+instantly from cache — it decides whether to ask by checking the service-worker
+cache, which is empty here. That one checkbox is the whole difference; see
+[`WINDOWS_ELECTRON_SPIKE.md`](WINDOWS_ELECTRON_SPIKE.md) §5.
+
+The privacy notice is separate and is shown **once** — accepting it is
+remembered, and it can be revoked from Settings.
 
 Also absent by design:
 

--- a/docs/WINDOWS_PREVIEW.md
+++ b/docs/WINDOWS_PREVIEW.md
@@ -1,0 +1,159 @@
+# SciREPL on Windows — preview builds
+
+Two ways to run the Free application on Windows. Neither is a release, and
+neither is a Microsoft Store package.
+
+| | You need | Best for |
+| --- | --- | --- |
+| [Portable preview](#1-portable-preview-no-tools-needed) | nothing | trying the app, sharing it with a tester |
+| [Developer launch](#2-developer-launch) | Node.js 22+, Git | changing the code |
+
+---
+
+## 1. Portable preview (no tools needed)
+
+A ZIP with a `SciREPL.exe` you can double-click. No Node, no Git, no web server,
+no installer, nothing written to the registry.
+
+### Get it
+
+1. Open the repository's **Actions** tab.
+2. Choose the **Windows portable preview** workflow.
+3. **Run workflow** → pick the branch → **Run workflow**. It takes roughly
+   15–25 minutes (it downloads Electron and ~104 MB of kernel runtimes).
+4. When it finishes, download the artifact named
+   `SciREPL-windows-x64-preview-<commit>` from the run summary.
+
+### Run it
+
+1. Extract the ZIP to a **local** folder — `C:\Users\<you>\SciREPL-preview` is
+   fine. Do not run it from inside the ZIP viewer, from a network share, or from
+   a `\\wsl.localhost\…` path.
+2. Run **`SciREPL.exe`**.
+
+### The SmartScreen warning is expected
+
+The preview is **unsigned**, so on first run Windows shows:
+
+> **Windows protected your PC**
+> Microsoft Defender SmartScreen prevented an unrecognised app from starting.
+
+Choose **More info → Run anyway**.
+
+This happens to every unsigned application and says nothing about whether the
+build is sound — SmartScreen is reporting the absence of a code-signing
+certificate and reputation history, not a detected problem. Signing is
+deliberately out of scope for a preview; it belongs with Store packaging.
+
+Only run a build you produced yourself, or one whose commit you can verify from
+the workflow run that made it.
+
+### What works, and what doesn't
+
+Bundled and fully offline:
+
+- **JavaScript**, **Bash/Brush**, **ClojureScript/Scittle**, **SWI-Prolog**,
+  **Python/Pyodide** (with numpy, pandas, sympy)
+
+Needs a network connection **every session**:
+
+- **Lua/Fengari** and **R/webR** are fetched from a CDN. They are *not* cached
+  for offline use, because the service worker's cache does not work under the
+  `app://` origin the shell serves from — see
+  [`WINDOWS_ELECTRON_SPIKE.md`](WINDOWS_ELECTRON_SPIKE.md) §5. Expect the
+  download prompt each time you start the app and use them.
+
+Also absent by design:
+
+- the **Ko-fi support button** in Help. The widget is a third-party script and
+  the shell's Content-Security-Policy does not allow it; the rest of Help is
+  unaffected. See `KOFI_EXCLUSION` in `desktop/electron/protocol.js`.
+
+Not present at all: any Pro content, Microsoft Store integration, licence or
+entitlement checking, or in-app purchase.
+
+### Where your data goes
+
+`%APPDATA%\SciREPL-Free-Electron` — notebooks, SharedVFS contents, settings.
+Deleting that folder resets the application. Uninstalling is deleting the
+extracted folder; nothing else is installed.
+
+---
+
+## 2. Developer launch
+
+For changing the shell or the application.
+
+### Prerequisites
+
+- **Node.js 22 or newer** for **Windows** — <https://nodejs.org/>. After
+  installing, close and reopen your terminal so `PATH` is picked up.
+- **Git for Windows**, or download the repository as a ZIP.
+- The repository on a **local** path such as
+  `C:\Users\<you>\Projects\SciREPL`. Not `\\wsl.localhost\…`: Windows Node
+  tooling and Electron do not handle UNC paths reliably, and the setup script
+  stops with an explanation if it finds one.
+- An ordinary, **non-administrator** PowerShell window. Nothing here needs
+  elevation, and nothing is installed system-wide.
+
+### One command
+
+```powershell
+cd C:\Users\<you>\Projects\SciREPL
+npm install
+npm run dev:windows
+```
+
+`dev:windows` does the whole first-run sequence and then launches the shell:
+
+1. checks Node ≥ 22 and reports the platform;
+2. configures the Free build profile;
+3. fetches the bundled runtimes (~100 MB, first run only);
+4. installs the isolated Electron dependencies under `desktop/electron/`;
+5. downloads the Electron binary (~220 MB, first run only);
+6. launches SciREPL.
+
+Steps already done are detected and skipped, so re-running it is cheap — it
+doubles as "just start the app". Close the window, or press `Ctrl+C`, to stop.
+
+```powershell
+npm run setup:windows   # same, but stop before launching
+npm run dev:windows -- --force   # redo every step
+```
+
+### Building a portable preview locally
+
+```powershell
+npm run package:windows
+```
+
+Output lands in `desktop/electron/out/SciREPL-win32-x64/`. Verify it with:
+
+```powershell
+node desktop/electron/test/run-all.mjs packaged
+```
+
+### When it will not start
+
+```powershell
+node desktop/electron/test/smoke.mjs
+```
+
+This launches the shell directly, without Playwright, and prints the main
+process's own output — Playwright reports a failed launch as a bare timeout with
+nothing useful in it. If the default launch fails it retries once with GPU and
+sandbox flags, which distinguishes a broken build from a host that needs them.
+
+---
+
+## Running through WSL
+
+If you are in WSL with WSLg, `npm run dev:windows` will run and a window will
+appear. Useful for a quick look at the interface.
+
+It is **not** a Windows test: you are launching the Linux Electron build
+displayed on a Windows desktop, not `SciREPL.exe`. Windows-specific behaviour —
+native dialogs, SmartScreen, display scaling, path handling, accessibility — is
+not exercised. The setup script prints this warning when it detects a non-Windows
+platform. For anything that matters, use the portable preview or a native
+developer launch.

--- a/docs/WINDOWS_PREVIEW.md
+++ b/docs/WINDOWS_PREVIEW.md
@@ -60,13 +60,22 @@ Bundled and fully offline:
 - **JavaScript**, **Bash/Brush**, **ClojureScript/Scittle**, **SWI-Prolog**,
   **Python/Pyodide** (with numpy, pandas, sympy)
 
+Needs a network connection the **first** time, then works offline:
+
+- **Lua/Fengari** (~200 kB) is fetched from a CDN. The service worker's cache
+  does not work under the `app://` origin, but Chromium's ordinary HTTP cache
+  retains something this small, so Lua keeps working offline after one online
+  use.
+
 Needs a network connection **every session**:
 
-- **Lua/Fengari** and **R/webR** are fetched from a CDN. They are *not* cached
-  for offline use, because the service worker's cache does not work under the
-  `app://` origin the shell serves from — see
-  [`WINDOWS_ELECTRON_SPIKE.md`](WINDOWS_ELECTRON_SPIKE.md) §5. Expect the
-  download prompt each time you start the app and use them.
+- **R/webR** (~50 MB) is too large for the HTTP cache to retain, and the cache
+  that would have held it is the broken one. Expect it to download each session.
+
+Either way you will see the **download prompt every session**, even when the
+files come straight from cache: the app checks the (empty) service-worker cache
+to decide whether to ask. Cosmetic — click through it and the load is instant if
+it was cached. See [`WINDOWS_ELECTRON_SPIKE.md`](WINDOWS_ELECTRON_SPIKE.md) §5.
 
 Also absent by design:
 
@@ -79,9 +88,14 @@ entitlement checking, or in-app purchase.
 
 ### Where your data goes
 
-`%APPDATA%\SciREPL-Free-Electron` — notebooks, SharedVFS contents, settings.
-Deleting that folder resets the application. Uninstalling is deleting the
-extracted folder; nothing else is installed.
+`%APPDATA%\SciREPL-Free-Electron` — notebooks and settings in `localStorage`,
+SharedVFS contents in IndexedDB. Deleting that folder resets the application.
+Uninstalling is deleting the extracted folder; nothing else is installed.
+
+The shell requests **persistent storage** for its origin, so Chromium will not
+discard your notebooks to reclaim disk space. (Android already gets this by
+having a private app data directory; a browser PWA does not, which is one of the
+few durable advantages the desktop build has.)
 
 ---
 

--- a/docs/WINDOWS_PREVIEW.md
+++ b/docs/WINDOWS_PREVIEW.md
@@ -62,15 +62,10 @@ Bundled and fully offline:
 
 Needs a network connection the **first** time, then works offline:
 
-- **Lua/Fengari** (~200 kB) is fetched from a CDN. The service worker's cache
-  does not work under the `app://` origin, but Chromium's ordinary HTTP cache
-  retains something this small, so Lua keeps working offline after one online
-  use.
-
-Needs a network connection **every session**:
-
-- **R/webR** (~50 MB) is too large for the HTTP cache to retain, and the cache
-  that would have held it is the broken one. Expect it to download each session.
+- **Lua/Fengari** and **R/webR** are downloaded from a CDN on first use and then
+  kept in the application's own data directory
+  (`%APPDATA%\SciREPL-Free-Electron\runtime-cache`). After that they work with
+  no network at all, and they survive restarts. R is ~23 MB cached; Lua ~0.2 MB.
 
 If you would rather not be asked before each runtime download, turn on
 **Settings → Runtime Downloads → "Auto-download runtimes (skip confirmation)"**.

--- a/docs/WINDOWS_PREVIEW.md
+++ b/docs/WINDOWS_PREVIEW.md
@@ -15,6 +15,11 @@ neither is a Microsoft Store package.
 A ZIP with a `SciREPL.exe` you can double-click. No Node, no Git, no web server,
 no installer, nothing written to the registry.
 
+The `win32-x64` build has been run on native Windows 11 and passes the full
+packaged suite (56 assertions): it launches, serves `app://scirepl/index.html`
+from its own bundled `resources\www`, keeps notebook code away from Node,
+runs the bundled kernels, and keeps notebook/SharedVFS state across a restart.
+
 ### Get it
 
 1. Open the repository's **Actions** tab.
@@ -145,6 +150,26 @@ nothing useful in it. If the default launch fails it retries once with GPU and
 sandbox flags, which distinguishes a broken build from a host that needs them.
 
 ---
+
+## Building a preview from WSL
+
+You do not need Windows Node to *produce* a preview — `@electron/packager`
+cross-builds, so a Windows package can be built from WSL and then run natively:
+
+```bash
+cd ~/Projects/SciREPL          # a checkout with the branch
+nvm use 22
+npm install
+npm run windows:install
+npm run package:windows        # produces desktop/electron/out/SciREPL-win32-x64/
+
+cp -r desktop/electron/out/SciREPL-win32-x64 /mnt/c/Users/<you>/SciREPL-preview
+```
+
+Then run `C:\Users\<you>\SciREPL-preview\SciREPL.exe` from Windows. Copy it
+to a real Windows path first — running from `\\wsl.localhost\…` is unreliable.
+
+This is a genuine native Windows build, unlike the WSLg launch below.
 
 ## Running through WSL
 

--- a/docs/proposal-package-update-checks.md
+++ b/docs/proposal-package-update-checks.md
@@ -1,0 +1,102 @@
+# Proposal: package update checks
+
+**Status:** design note for a follow-up PR. Nothing here is implemented.
+
+Recorded while adding the desktop runtime cache (PR #57), because that cache and
+this feature share one constraint: an update checker is only as good as the
+freshness of the data it reads.
+
+## Why this is a separate change
+
+PR #57 added a persistent runtime cache so language runtimes keep working
+offline. That is a *runtime asset* concern. Deciding whether an installed
+**package** is out of date is a *user-facing product* concern with its own UI,
+settings and consent rules. Bundling them would have made a cache fix into a
+feature release.
+
+The one piece that could not wait is the cache policy itself — see
+[Cache constraints](#cache-constraints).
+
+## Scope
+
+A "Check for package updates" command under the **Packages** menu, plus the
+surrounding behaviour:
+
+| Behaviour | Default |
+| --- | --- |
+| Manual **Check for package updates** command | always available |
+| Automatic background checks | **off** initially |
+| Outdated-package notification | non-blocking; never a modal that interrupts work |
+| **Update** action | always requires explicit confirmation |
+| **Ignore this version** | per package, per version |
+| **Don't notify for this package** | per package, permanent until reset |
+| Global "disable update warnings" | in Settings, alongside the existing runtime-download toggle |
+| Offline | keep using installed versions; never block, never nag |
+
+Two rules that should not be negotiable:
+
+1. **Never update automatically without confirmation.** Packages can change
+   notebook behaviour. A silent update that alters a result is worse than an
+   outdated package.
+2. **Never block work on a check.** A failed or slow update check is a
+   background condition, not an error state.
+
+## Cache constraints
+
+This is the part that constrains implementation, and it is already handled in
+PR #57 so a future checker starts from correct data.
+
+`repo.r-wasm.org` is a **mutable** package repository: its `PACKAGES` indexes
+describe what exists *right now*. The desktop runtime cache keeps responses
+indefinitely, which is right for version-pinned runtime assets and wrong for
+repository metadata — an update checker reading a permanently cached index would
+report "up to date" forever.
+
+PR #57 therefore splits the policy:
+
+| Request | Cached? |
+| --- | --- |
+| `…/v0.5.4/R.wasm`, `scittle@0.6.22/…`, `ggplot2_3.5.1.tgz` | yes, indefinitely — version-pinned and immutable |
+| `…/PACKAGES`, `PACKAGES.gz`, `PACKAGES.rds`, `PACKAGES.json` | **never** — mutable repository index |
+| any URL with a query string | **never** — assumed parameterised |
+| `404` on a version-pinned path | yes — permanently true, and webR's `HEAD` probes need it offline |
+| `404` on a mutable path | **never** — a package absent today may exist tomorrow |
+
+Consequence to keep in mind when building this feature: **checking for updates
+requires a network connection**, by design. Offline, the honest answer is "not
+checked recently", not a stale "up to date".
+
+The same reasoning applies to the GitHub release metadata behind
+`package_catalog.js` (`api.github.com`), which is deliberately not on the
+cacheable-host list at all.
+
+## Suggested shape
+
+1. **A pure comparison layer first** — given installed versions and available
+   versions, produce a list of outdated packages. Testable with no network and
+   no UI, and shareable across the PWA, Android and desktop.
+2. **A fetch layer** that reads the catalogue/index, with explicit
+   `checkedAt` timestamps so the UI can say *when* it last knew.
+3. **UI last**, once the first two are covered by tests.
+
+State worth persisting per package: `ignoredVersion`, `notifyDisabled`,
+`lastCheckedAt`, `lastKnownAvailable`. This belongs in the same
+`localStorage`-backed settings the rest of the app uses, so it survives restarts
+and stays consistent across platforms.
+
+## Cross-platform
+
+The comparison and fetch layers belong in shared `www/` code so the PWA,
+Android and the desktop shell behave identically — the same rule that made the
+runtime-download consent setting work everywhere. Only the *presentation* should
+differ, and ideally not even that.
+
+## Open questions
+
+1. Which sources are in scope — SciREPL workbook/package catalogue only, or also
+   R (`repo.r-wasm.org`) and Python (`micropip`/PyPI)? Each has different
+   version semantics.
+2. What does "outdated" mean for a workbook whose content changed but whose
+   version did not?
+3. Should an automatic check ever run on a metered connection?
+4. How is a check surfaced when it fails repeatedly — silently, or once?

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
         "build:release:apk": "npm run configure && npm run fetch:bundles && npx cap sync && cd android && ./gradlew assembleRelease",
         "build:play": "npm run build:release:aab",
         "windows:install": "npm --prefix desktop/electron install && node desktop/electron/node_modules/electron/install.js",
-        "dev:windows": "npm run configure && npm run fetch:bundles && npm --prefix desktop/electron start",
+        "dev:windows": "node desktop/electron/scripts/dev-windows.mjs",
+        "setup:windows": "node desktop/electron/scripts/dev-windows.mjs --skip-launch",
+        "package:windows": "node desktop/electron/packaging/build-portable.mjs",
         "test:windows": "node desktop/electron/test/run-all.mjs",
         "test:windows:unit": "node desktop/electron/test/run-all.mjs --unit"
     },


### PR DESCRIPTION
Makes the Free Electron shell easy to launch and evaluate on Windows without a toolchain, and fixes three real defects found while doing it.

Post-merge cleanup from PR #56 was already shipped in `32c5ebf` — verified, not redone.

## Deliverables

- **`npm run dev:windows`** — one command: checks Node ≥ 22 and platform, configures the Free profile, fetches runtimes, installs isolated Electron deps, provisions the binary, launches. Skips completed steps. No elevation, nothing system-wide. Warns (not fails) on non-Windows, since WSLg runs the *Linux* build.
- **Portable preview** — `@electron/packager` pinned at 20.2.0; `workflow_dispatch` workflow producing `SciREPL-windows-x64-preview-<sha>`. The artifact *is* the ZIP: extract, run `SciREPL.exe`. Optional `linux` input cross-builds a Linux x64 asset (uploaded built-not-tested).
- **`packaged.test.mjs`** — 59 assertions against the real binary with `SCIREPL_WWW` unset, so it must find its own bundled tree. Reuses `probes/security.mjs` and `probes/kernels.mjs` rather than restating them.

## Verified on native Windows

`SciREPL.exe` executed on Windows 11: launches, serves `app://scirepl/index.html` from its own `resources\www`, all 59 packaged assertions pass with `platform: "win32"`. Manual session confirmed workbook install from Browse Packages and PDF export.

## Defects found and fixed

- **Packaged layout** — `main.js` derived paths from `__dirname`, which is inside `app.asar` once packaged. `www/` and the version lookup would both have broken *silently*. `paths.js` now resolves both layouts as unit-tested pure functions.
- **Storage was not persistent** — measured `persisted() → false`. A blanket permission denial was refusing `persistent-storage`, leaving notebooks in evictable storage. Fixed with a narrow exception; now measured true. (Android already had this via its private data dir.)
- **Window could never be shown** — `ready-to-show` never fires under WSLg, leaving a window that owns a taskbar entry but can't be raised. Now shows on the first of four signals.
- **Pro material in the artifact** — the first build shipped `www/pro/` (~800 kB of Pro branding). Filtered from the staged copy; asserted absent twice. **The website is unaffected** — `www/pro/**` stays tracked and `deploy-pages.yml` is unchanged.

## Offline runtime cache

`runtime-cache.js` caches CDN runtimes in `userData/runtime-cache/`. **R went from timing out after 86 s to running offline in ~1 s.** Two things webR needed that only measurement found: it probes with `HEAD` before `GET`, and it probes for optional files (so 404s must be cached too).

This supersedes the earlier recommendation to bundle runtimes into the Windows profile — offline R no longer costs 50 MB, and the Free/Pro profile difference stays intact.

## Corrections to earlier claims

Several things I'd stated were wrong and are now measured:
- "CDN kernels need the network every session" — only R did; Lua survived via the HTTP cache
- "the consent prompt is a papercut needing a Phase 1 fix" — it's a persisted Settings toggle, identical on Android
- root cause of the cache problem — the SW *registers* then dies during install; caching https from `app://` works fine

## Also

Real application menu (replaces Electron's default, whose Help links to electronjs.org) carrying the only surface that can inspect or clear the runtime cache — the in-app Memory & Storage panel can't see it, and that's documented as an open consistency decision against Android.

DevTools verified to work packaged **and** to widen nothing: `require`/`process` undefined, Function-ctor escape blocked, platform API unchanged.

## Scope

`www/` is byte-identical to `main`. No Android, Capacitor, PWA, build-profile or existing-workflow file touched. Root `package.json` gains three scripts.

Suites: development 177, packaged 59, runtime-cache 11 — 0 failures.