### PR TITLE
Design: catalog search, spoken-language filter, and source URLs

### DIFF
--- a/docs/local-fetch-helper.md
+++ b/docs/local-fetch-helper.md
@@ -1,0 +1,139 @@
+# Local fetch helper: installing from hosts the browser can't read
+
+Some catalog items — and some catalog sources — live on hosts that don't send
+CORS headers. When you tap **Install** on one of those in the PWA (or in the
+Electron app), the browser refuses the download and SciREPL shows a
+cross-origin error. This page explains your options, from least to most
+friction.
+
+## Option 1: Use the Android app (least friction)
+
+The Android build downloads through Capacitor's native HTTP layer, which is
+not bound by browser CORS rules at all. The same install that failed in the
+PWA just works there. If you have an Android device and expect to install
+from GitHub Releases or other non-CORS hosts regularly, this is the
+lowest-friction path.
+
+> **What about Electron?** The plan is to give the desktop shell a
+> narrow, allowlist-scoped fetch channel in the main process: the
+> renderer asks for a URL, the main process fetches it (no CORS outside a
+> renderer), and only destinations on a fixed allowlist are permitted —
+> with the GitHub family (`github.com`, `raw.githubusercontent.com`,
+> `objects.githubusercontent.com`, `cdn.jsdelivr.net`) on that list by
+> default. This is safe to expose even though notebook code shares
+> `window` with the UI, because the filter constrains the *destination*,
+> not the *caller* — the worst a hostile notebook can do is download
+> content from an allowlisted host.
+>
+> Until that channel ships, Electron enforces the same CORS rules as the
+> PWA (`webSecurity` is on, and today there is no privileged download
+> IPC), so treat it as "PWA rules" and use this helper or Android. Once
+> it ships, Electron joins Android as a low-friction path for
+> GitHub-hosted content.
+
+## Option 2: Run the local fetch helper
+
+The helper is a tiny Node server you run on your own machine. It fetches the
+URL for you — no CORS in a plain server-to-server fetch — and hands the bytes
+back to the app with the headers the browser requires. This is the same
+pattern as SciREPL's dev-server `/proxy`, generalized beyond GitHub
+Releases, and the same sidecar pattern UnifyWeaver uses for browser agents.
+
+### Requirements
+
+- Node.js 18 or newer (`node --version` to check). No npm install, no
+  dependencies — it uses only the standard library.
+
+### Start it
+
+```bash
+node local-fetch-helper.mjs
+# SciREPL local fetch helper: http://127.0.0.1:8787/
+```
+
+Then retry the install in SciREPL. Leave the helper running while you
+install; stop it with Ctrl+C when you're done.
+
+To use a different port: `PORT=9000 node local-fetch-helper.mjs`.
+
+### What it does and doesn't allow
+
+- Listens on `127.0.0.1` **only** — nothing else on your network can reach it.
+- Fetches `https://` URLs only. No embedded credentials, no `http:`, at most
+  5 redirects, and a redirect that downgrades to `http:` is refused.
+- Caps responses at 64 MB (`MAX_BYTES` to change), so a broken or hostile
+  upstream can't eat your disk.
+- Sends `Access-Control-Allow-Origin: *` and answers Private Network Access
+  preflights — that's the point of the helper, and also its trade-off:
+  **while it runs, any web page open in your browser can ask it to fetch
+  anything your machine can reach over HTTPS.** The URLs it fetches are
+  whatever a page asks for. If that makes you uncomfortable, run it only
+  during installs (as suggested above) rather than leaving it up.
+
+### If the app is a hosted PWA (https://…github.io)
+
+A secure public page calling `http://127.0.0.1` is a *private network
+request*. Chrome sends a CORS preflight with
+`Access-Control-Request-Private-Network: true`, and the helper answers with
+`Access-Control-Allow-Private-Network: true`, which is what current Chrome
+requires. If a future browser version blocks this flow anyway, the fallback
+is to serve SciREPL itself locally (`npm run serve`) so page and helper are
+both on localhost.
+
+### Verifying it's running
+
+```bash
+curl http://127.0.0.1:8787/health
+# {"ok":true}
+```
+
+## Option 3: Serve SciREPL locally
+
+`npm run serve` starts the dev server, which includes its own `/proxy` for
+GitHub release downloads, and puts the app and the proxy on the same
+localhost origin — sidestepping both CORS and Private Network Access rules.
+This is the power-user configuration and works today; the helper above is
+the lighter-weight version of the same idea.
+
+The deeper advantage of running your own server is that it can serve
+**custom content**, not just relay GitHub. A server you control can:
+
+- **Front a special API.** Add an endpoint that calls a private or
+  rate-limited API and re-shapes the response for the app. Because the
+  request originates server-side, CORS never applies — and API keys can
+  live in the server's environment instead of in renderer code or a
+  notebook. (Notebooks can still *call* your local endpoint, so treat the
+  endpoint itself as public-within-your-machine, but the key never has to
+  leave the server.)
+- **Publish a local catalog source.** Put a `scirepl-catalog.json` and its
+  artifacts behind your server and add `http://127.0.0.1:PORT/…` — or a LAN
+  address, for a household/lab server — as a source. Content that never
+  touches GitHub at all: private datasets, generated workbooks,
+  institution-internal packages.
+- **Extend rather than replace.** `server.js` is ~100 lines of plain Node;
+  adding a route is a few lines. The same file serves the app, the proxy,
+  and whatever you add, all on one origin.
+
+If you go this route, the helper's security rules still apply: bind to
+`127.0.0.1` unless you genuinely mean to serve your LAN, validate upstream
+URLs, and cap response sizes.
+
+## Option 4: Manual import
+
+Every install card is ultimately just a file. Download it yourself in the
+browser (no CORS applies to a plain navigation/download), then use
+**Menu → Import Package** in SciREPL. No helper, no server, works on every
+platform.
+
+## For catalog source authors
+
+If you publish a catalog (`scirepl-catalog.json`) or workbooks meant for
+PWA and Electron users, host both the index and the artifacts on a
+CORS-open host so none of the above is needed:
+
+- `raw.githubusercontent.com/<owner>/<repo>/…`
+- `cdn.jsdelivr.net/gh/<owner>/<repo>@<ref>/…`
+
+GitHub Releases (`github.com/…/releases/download/…`) are convenient for
+large files but install only on Android, via a local helper/proxy, or by
+manual import — they send no CORS headers.

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -1,0 +1,374 @@
+# Proposal: searchable catalog, language filter, and catalog sources
+
+**Status:** design note. Nothing here is implemented.
+
+The Browse Packages, Bundles & Workbooks modal is a hardcoded list in
+`www/js/package_catalog.js`. Every curated entry is shown, in a fixed
+Packages → Bundles → Workbooks order, with no search, no kernel filter, and
+no way to point SciREPL at another repo. This note proposes keeping that
+curated list as the **default view**, then adding:
+
+1. A search field that can surface **additional** items, not just filter the
+   defaults.
+2. A language filter that **defaults to the kernel currently selected** in
+   the editor (`#lang-selector` / `kernelManager.currentLanguage`).
+3. A Sources panel for **catalog index URLs** (typically GitHub repos that
+   publish workbooks and packages).
+
+The hard part is not the UI. It is where those extra items live, and which
+platforms can fetch them. SciREPL has no production backend. The `/proxy`
+on `npm run serve` is a local-dev GitHub-release helper, not a PWA feature.
+
+## Why this shape
+
+The current catalog is small on purpose: it is the set of items that install
+offline from same-origin `pages_url` copies bundled with the app. That is
+the right default. Hiding it behind a remote registry, or replacing it with
+whatever a search index returns, would make the first-open experience
+depend on the network and on CORS.
+
+Search should **widen** the pool, not replace it:
+
+| Search box | What you see |
+| --- | --- |
+| Empty | Built-in curated entries, after the language filter |
+| Non-empty | Built-in matches **plus** matches from enabled catalog sources |
+
+Typing a query is what justifies extra network work. Opening Browse with an
+empty search stays a local, offline-capable view of the same items as today
+(language-sliced).
+
+## Current behaviour (the baseline we must not regress)
+
+- Catalog data is a JS array getter, `PackageCatalog.packages`.
+- Each entry is `package`, `bundle`, or `workbook`, with `kernels`, optional
+  `requires` / `items`, and a fetch source (`pages_url` and/or `url`).
+- Install tries `pages_url` first (same-origin, works in the PWA, Android
+  WebView, and Electron), then the GitHub release `url`.
+- `_fetchPackage` already has a platform cascade:
+
+  1. Same-origin / relative URL → `fetch`
+  2. Capacitor native `Filesystem.downloadFile` (Android)
+  3. Direct `fetch` (needs CORS)
+  4. `/proxy?url=...` (dev server only; GitHub **release downloads** only)
+
+- Production GitHub Pages has **no proxy**. Release URLs without CORS only
+  work because the same files are also shipped as `pages_url`.
+- Electron enables `webSecurity` and exposes **no download IPC**. The
+  renderer is treated as untrusted (notebook JS shares `window`). Electron
+  is therefore in the same CORS boat as the PWA, not the same boat as
+  Android.
+- `test_browse_catalog.mjs` asserts the modal opens with all three sections
+  and at least 17 cards. A default language filter will hide entries unless
+  tests select “All languages” or the current kernel is one that every
+  fixture uses.
+
+## UI
+
+Mobile-first, inside the existing catalog modal. No stacked second modal for
+the everyday controls; Sources is a panel you push/pop in the same dialog.
+
+```
+┌ Browse Packages, Bundles & Workbooks ──────────── × ┐
+│ One-click install packages, bundles, and workbooks. │
+│                                                     │
+│ [ Search packages, bundles, workbooks… ]  [Sources] │
+│ Language: [ Python            v ]                   │
+│                                                     │
+│ Packages                                            │
+│   UnifyWeaver SciREPL          prolog, python  [✓]  │
+│ Bundles                                             │
+│   … only if they include Python …                   │
+│ Workbooks                                           │
+│   Life Expectancy Analysis     python, r      [Install]
+│   Compute Pi …                 python         [Install]
+│   Tidyverse Data Wrangling     python, r      [Install]
+└─────────────────────────────────────────────────────┘
+```
+
+With Python selected and an empty search, Prolog-only and R-only cards
+disappear. That is the filter working, not a different catalog. **All
+languages** restores today’s full list in one tap.
+
+Sources panel (same modal, back chevron):
+
+```
+┌ ‹ Catalog sources ──────────────────────────────── × ┐
+│ Built-in SciREPL catalog              on  (pinned)   │
+│                                                      │
+│ [ https://github.com/user/workbooks          ] [Add] │
+│                                                      │
+│ My workbooks  github.com/user/workbooks              │
+│   last fetched 2h ago · 12 items            [on] [–] │
+│   fetch failed: blocked by browser CORS      [Retry] │
+│                                                      │
+│ Extra items appear when you search. HTTPS only.      │
+│ GitHub repos need a scirepl-catalog.json that the    │
+│ browser is allowed to read (see CORS below).         │
+└──────────────────────────────────────────────────────┘
+```
+
+### Language filter rules
+
+- Options: **All languages**, then every kernel in `#lang-selector`
+  (python, prolog, bash, javascript, r, lua, typr, clojurescript).
+- On open, set the filter to `kernelManager.currentLanguage`. Changing the
+  editor language while the modal is already open does **not** retarget the
+  filter; reopening does.
+- An entry matches when `kernels` is missing, or contains the selected
+  kernel. Multi-kernel workbooks (python+r) show for either kernel.
+- A bundle matches if its own `kernels` matches, or if any of its `items`
+  would match. Showing a bundle that then installs hidden Prolog workbooks
+  is acceptable; the bundle card already lists what it contains.
+- Empty sections omit their header (already true).
+- Persist the last **explicit** choice? No. Always re-default to the
+  current kernel on open, so the control stays a view over “what I am
+  writing now”, not a hidden setting.
+
+### Search rules
+
+- Filter name, description, id, kernel ids, and bundle contents.
+- Case-insensitive substring is enough for v1. No fuzzy ranking.
+- Empty query: built-in entries only (after language filter). **Do not**
+  show remote-source items, and **do not** fetch remote indexes.
+- Non-empty query: union of built-in matches and enabled-source matches.
+  Fetch each enabled source the first time a query is run this session
+  (then keep it in memory). A Sources “Retry” / toggle-on also fetches.
+- Built-in hits stay at the top of each section; source hits follow, with
+  a small origin label (`user/workbooks`) so it is obvious they are not
+  curated.
+- Offline / CORS failure on a source: keep built-in results, show one
+  non-blocking line under the toolbar (“2 sources unavailable”). Never
+  empty the default catalog because a remote index failed.
+
+### Sources rules
+
+- Built-in catalog is pinned, always on, not editable.
+- User sources persist in `localStorage` (same family as installed-package
+  state). Shape: `{ id, url, enabled, label?, lastFetchedAt?, lastError? }`.
+- HTTPS only. Reject credentials in the URL, `javascript:`, and non-https
+  schemes. Same stance as Electron’s external-open policy.
+- Adding a **GitHub repo URL** (`https://github.com/owner/repo`) is a
+  convenience: resolve it to a catalog index, do not scrape HTML.
+- Adding a **direct index URL** (`…/scirepl-catalog.json`) is the
+  primitive. Repo paste is sugar over that.
+- Removing a source does not uninstall anything already imported.
+
+## Catalog index format
+
+Keep it aligned with the in-app entry schema so `_renderCard` / `_install`
+can consume remote items without a second type.
+
+```json
+{
+  "format_version": "1.0",
+  "name": "Example workbooks",
+  "source": "https://github.com/example/scirepl-workbooks",
+  "items": [
+    {
+      "id": "example-pi",
+      "name": "Compute Pi",
+      "description": "Archimedean bounds notebook.",
+      "type": "workbook",
+      "kernels": ["python"],
+      "url": "https://raw.githubusercontent.com/example/scirepl-workbooks/main/pi.srwb",
+      "size": "~6 KB",
+      "revision": 1,
+      "format": "srwb"
+    }
+  ]
+}
+```
+
+Rules for remote items:
+
+- `id` must be unique **within that source**. The app namespaces as
+  `sourceId:itemId` so two repos can both ship `intro`.
+- `url` is the installable artifact. For the PWA it must be a CORS-open
+  HTTPS URL (see below). `pages_url` on a remote item is only useful if it
+  is same-origin with the running app, which community repos will not be.
+- No `displayNameKey` / i18n keys from remote JSON. Remote text is shown
+  as authored. The chrome (Search, Sources, section headers, errors)
+  stays in the i18n catalogues.
+- Ignore unknown fields. Reject the whole index if `format_version` is
+  newer than we understand, and say so in `lastError`.
+- Cap index size (e.g. 500 items / 1 MB JSON) so a huge file cannot stall
+  a phone.
+
+### Resolving a GitHub repo URL
+
+Try, in order, and stop on the first JSON that parses as a catalog:
+
+1. `https://cdn.jsdelivr.net/gh/owner/repo@HEAD/scirepl-catalog.json`
+2. `https://raw.githubusercontent.com/owner/repo/HEAD/scirepl-catalog.json`
+3. `https://owner.github.io/repo/scirepl-catalog.json` (often **fails CORS**
+   when `owner` is not the SciREPL Pages host)
+
+Do **not** call `api.github.com` from every Browse session. Unauthenticated
+GitHub API is 60 requests/hour/IP; a popular PWA would burn that immediately.
+
+jsDelivr is already in the privacy policy for runtime version checks, so it
+is a known optional network peer. Prefer it as the first probe because it
+sends CORS headers and sits on a CDN.
+
+## Cross-origin: what actually works
+
+This is the issue. There is no general “fetch this GitHub repo” that works
+everywhere.
+
+| Surface | Built-in `pages_url` | GitHub **release** zip/ipynb | `raw.githubusercontent.com` / jsDelivr | Other GitHub Pages origin | Arbitrary HTTPS |
+| --- | --- | --- | --- | --- | --- |
+| PWA on GitHub Pages | Yes (same origin) | **No** (no CORS, no `/proxy`) | Yes, if the file is public | **Usually no** (Pages does not send `ACAO`) | Only if that host sends CORS |
+| `npm run serve` | Yes | Yes, via `/proxy` **only** for `github.com/…/releases/download/` | Yes, if CORS | Usually no | No, proxy will 403 |
+| Android (Capacitor) | Yes | Yes (native HTTP) | Yes | Yes | Yes (native HTTP) |
+| Electron | Yes | **No** (CORS, and no download IPC) | Yes, if CORS | Usually no | Only if CORS |
+
+Two surprises relative to the usual “native apps ignore CORS” intuition:
+
+1. **Electron is not Android.** `desktop/electron/security.js` treats the
+   renderer as fully untrusted because the JavaScript kernel (and Scittle,
+   Fengari, Pyodide’s JS bridge) share `window`. There is no privileged
+   “download this URL” channel, on purpose. Adding one for catalog sources
+   would be reachable from notebook code. **Do not add it for this feature.**
+   Electron stays on the PWA fetch rules.
+2. **The PWA cannot grow a proxy** without becoming a hosted backend, which
+   SciREPL is not. Extending `server.js` `/proxy` helps local development
+   only. It does not help `*.github.io` installs, F-Droid WebView builds
+   that load Pages, or a service-worker-cached PWA opened from the home
+   screen.
+
+### Practical consequence for source authors
+
+If a catalog is meant to work in the **PWA and Electron**, both the index
+and the artifacts must be on a CORS-open host. The reliable public options
+today:
+
+- `raw.githubusercontent.com/owner/repo/…`
+- `cdn.jsdelivr.net/gh/owner/repo@ref/…`
+
+GitHub **Releases** (`github.com/…/releases/download/…`) are the right
+place for large zips in the *built-in* catalog, because we also ship
+`pages_url`. They are the **wrong** default for community sources: they
+install on Android, and on `npm run serve`, and nowhere else.
+
+Same-org GitHub Pages is a narrow extra: `https://s243a.github.io/other-repo/…`
+is same-origin with the SciREPL PWA, so it would work without CORS. That is
+an implementation accident, not a community-source strategy.
+
+### Error copy when CORS blocks an install
+
+Do not dump a raw `TypeError: Failed to fetch`. Say which platform can
+still do it, and offer the existing manual path:
+
+> This file is on a host the browser will not read (cross-origin). On
+> Android it would download directly. Elsewhere, download it yourself and
+> use Menu → Import Package.
+
+Sources that fail at **index** fetch get a Retry on the Sources panel, not
+a modal.
+
+## Privacy and consent
+
+Today, catalog installs are user-initiated downloads from GitHub, already
+disclosed. Two new behaviours need a policy line **when they ship**, not
+in this design-only PR:
+
+1. Fetching a user-added `scirepl-catalog.json` (and jsDelivr/GitHub as
+   the resolved host).
+2. Fetching the artifact URL when the user taps Install on a search hit.
+
+Empty-search Browse must not hit the network. That keeps the default view
+honest offline and avoids a surprise request on every menu open.
+
+Do not probe sources in the background. Do not send the search string to
+any server; filtering is local against indexes the user enabled.
+
+## Trust
+
+A catalog source is as trusted as “Import Package” from a URL the user
+pasted. SciREPL already executes installed notebooks and package JS
+wrappers. Sources do not change that, but the UI should make origin
+visible on every remote card.
+
+Refuse to follow redirects off HTTPS. Cap download size with the same
+instinct as package install (show `size` from the index; if the host
+sends a huge `Content-Length`, abort).
+
+## What we are not doing
+
+- A central SciREPL registry or search API. No backend.
+- Scraping GitHub repo file trees or README pages.
+- Using `api.github.com` as the everyday index.
+- Auto-adding community repos. The built-in list stays the default.
+- Changing which items are in the built-in array. Search finds *more*;
+  it does not demote UnifyWeaver, ggplot2, TypR, etc.
+- An Electron or PWA CORS bypass.
+- Filtering by UI locale. “Language” here is the **kernel**, not i18n.
+
+## Suggested implementation order
+
+Keep the comparison/filter layer pure and testable without a browser,
+same split as `docs/proposal-package-update-checks.md`.
+
+1. **Pure filter** — given entries, a query string, and a kernel id,
+   return the visible list. Unit-testable in node. Covers “empty query
+   ⇒ built-in only”, kernel membership, bundle matching, namespacing.
+2. **Catalog UI** — search input, language `<select>`, empty-state copy.
+   Wired only to the built-in array. `test_browse_catalog.mjs` must
+   select All languages (or the test kernel) before counting cards, so
+   the default-filter change does not look like a missing workbook.
+3. **Index fetch + Sources panel** — persist sources, resolve GitHub
+   repo URLs, parse `scirepl-catalog.json`, union on search. CORS
+   failures are first-class UI, not console noise.
+4. **Install from remote hits** — reuse `_fetchPackage`. On PWA/Electron
+   CORS failure, the manual-import message above. Android uses native
+   HTTP as it already does.
+5. **Privacy policy** — one paragraph for user-added catalog sources,
+   kept in sync with `privacy:check`.
+6. **Docs** — a short “Publishing a catalog source” section in
+   `docs/packages.md` once the JSON schema is real.
+
+Phase 2 is already a useful PR on its own (search + language filter over
+today’s list). Phase 3 is what makes search find *more*. Do not ship
+Sources without the CORS error path; a button that adds a GitHub release
+URL and then fails silently on the PWA is worse than no button.
+
+## Test notes
+
+- `test_browse_catalog.mjs` currently assumes every built-in card is
+  visible on open. After phase 2 it should assert:
+  - default filter equals the current kernel (python in the fixture);
+  - All languages restores ≥ 17 cards and the three section headers;
+  - a query that matches only a remote fixture appears only after the
+    source is enabled (phase 3, with a stub index, not live GitHub).
+- Do not hit the network in CI for source tests. Serve a tiny
+  `scirepl-catalog.json` from the same origin via `server.js`.
+- A Playwright case that points at a cross-origin URL **without** CORS
+  headers should assert the unavailable-source line, not a thrown error.
+
+## Open questions
+
+1. **Default language vs “same defaults”.** Defaulting to the current
+   kernel *does* hide some of today’s cards (open Browse on Python, and
+   the Lua/TypR/Prolog-only workbooks are gone until you pick All). That
+   matches “filter defaults to the selected language.” If first-open
+   must be byte-for-byte the current list, default the control to All
+   and keep “Current language” as a one-tap chip instead. Recommendation:
+   default to the current kernel; All is one tap.
+2. **Should a non-empty search that matches nothing in sources still
+   show built-in misses?** No. Search filters everything. Zero hits is
+   allowed; keep the empty copy explicit (“No matches in the built-in
+   catalog or 2 sources”).
+3. **jsDelivr vs raw.githubusercontent.com as the documented author
+   path.** Both work in the PWA. jsDelivr caches; raw is canonical.
+   Resolve both; document raw as the file you put in the repo and
+   jsDelivr as the URL the app will try first.
+4. **F-Droid / Android WebView loading Pages rather than the Capacitor
+   shell.** If a build ever loads the PWA URL inside a WebView *without*
+   the Filesystem plugin, it inherits PWA CORS. Native HTTP is a
+   Capacitor-shell feature, not “any Android”.
+5. **Related work.** Package *update* checks
+   (`docs/proposal-package-update-checks.md`) also need a fetch layer
+   and must not cache mutable indexes forever. If both ship, they should
+   share “fetch this HTTPS JSON with CORS/native cascade” rather than
+   growing two helpers. Out of scope for the first catalog-browse PR.

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -12,8 +12,8 @@ curated list as the **default view**, then adding:
    defaults.
 2. A **spoken-language** filter (interface / content locale) that **defaults
    to the app’s current locale** (`i18n.current`), plus an ordered **fallback
-   list** (initialized to English) and a control for whether fallbacks are
-   allowed.
+   list** initialized to English with **Allow fallbacks on**. The user can
+   turn fallbacks off or edit the list; first run must not start strict.
 3. A **programming-language** filter (kernel) as a second control, defaulting
    to All so the first-open list stays the same as today.
 4. A Sources panel for **catalog index URLs** (typically GitHub repos that
@@ -173,7 +173,7 @@ Two pieces, not one dropdown:
 | Piece | Session or persisted | Default |
 | --- | --- | --- |
 | **Primary** (the spoken-language select) | Session. Reset on each open. | `i18n.current` |
-| **Fallbacks** (ordered list) + **Allow fallbacks** | Persisted in `localStorage` | `fallbacks: ['en']`, `allowFallbacks: true` |
+| **Fallbacks** (ordered list) + **Allow fallbacks** | Persisted in `localStorage` | First run: `fallbacks: ['en']`, `allowFallbacks: true`. Missing or corrupt storage re-initializes to that pair, not to fallbacks-off. |
 
 Effective preference order is:
 
@@ -244,6 +244,10 @@ Stored shape:
   "fallbacks": ["en"]
 }
 ```
+
+A missing `allowFallbacks` key is **true**, not false. First launch, wiped
+storage, and a partial write must all come up with fallbacks allowed and
+English on the list. Only an explicit user off-toggle stores `false`.
 
 ### Programming-language filter (defaults to All)
 

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -1,21 +1,29 @@
-# Proposal: searchable catalog, language filter, and catalog sources
+# Proposal: searchable catalog, language filters, and catalog sources
 
 **Status:** design note. Nothing here is implemented.
 
 The Browse Packages, Bundles & Workbooks modal is a hardcoded list in
 `www/js/package_catalog.js`. Every curated entry is shown, in a fixed
-Packages → Bundles → Workbooks order, with no search, no kernel filter, and
-no way to point SciREPL at another repo. This note proposes keeping that
+Packages → Bundles → Workbooks order, with no search, no filters, and no
+way to point SciREPL at another repo. This note proposes keeping that
 curated list as the **default view**, then adding:
 
 1. A search field that can surface **additional** items, not just filter the
    defaults.
-2. A language filter that **defaults to the kernel currently selected** in
-   the editor (`#lang-selector` / `kernelManager.currentLanguage`).
-3. A Sources panel for **catalog index URLs** (typically GitHub repos that
+2. A **spoken-language** filter (interface / content locale) that **defaults
+   to the app’s current locale** (`i18n.current`).
+3. A **programming-language** filter (kernel) as a second control, defaulting
+   to All so the first-open list stays the same as today.
+4. A Sources panel for **catalog index URLs** (typically GitHub repos that
    publish workbooks and packages).
 
-The hard part is not the UI. It is where those extra items live, and which
+The two “language” controls are different senses. The i18n catalogues
+already keep them apart (`Language-Interface` vs `Language-Programming` in
+`www/i18n/manifest.json`). The first draft of this note used the kernel for
+the default filter; that was the wrong sense. Spoken language is the one
+that should follow the app. Kernel is optional extra narrowing.
+
+The hard part is still not the UI. It is where extra items live, and which
 platforms can fetch them. SciREPL has no production backend. The `/proxy`
 on `npm run serve` is a local-dev GitHub-release helper, not a PWA feature.
 
@@ -29,20 +37,30 @@ depend on the network and on CORS.
 
 Search should **widen** the pool, not replace it:
 
-| Search box | What you see |
-| --- | --- |
-| Empty | Built-in curated entries, after the language filter |
-| Non-empty | Built-in matches **plus** matches from enabled catalog sources |
+| Search box | Spoken language | What you see |
+| --- | --- | --- |
+| Empty | app locale (default) | Built-in curated entries, same as today. Kernel filter only if the user changed it from All. |
+| Non-empty | app locale (default) | Built-in matches **plus** source matches whose **content locale** includes the selected spoken language |
+| Non-empty | All spoken languages | Built-in matches plus source matches in any locale |
 
 Typing a query is what justifies extra network work. Opening Browse with an
-empty search stays a local, offline-capable view of the same items as today
-(language-sliced).
+empty search stays a local, offline-capable view of the same items as today.
+
+That split also resolves the locale mismatch in the built-in catalog:
+**card chrome is translated, notebook content is English.** A Japanese UI
+still shows UnifyWeaver and ggplot2 on first open (names and descriptions
+come from `www/i18n/ja.json`). Search is how you find a Japanese-language
+workbook from a source you added. The spoken-language filter is the default
+scope for that wider pool, not a knife that cuts the curated list down to
+whatever happens to be authored in `ja`.
 
 ## Current behaviour (the baseline we must not regress)
 
 - Catalog data is a JS array getter, `PackageCatalog.packages`.
 - Each entry is `package`, `bundle`, or `workbook`, with `kernels`, optional
   `requires` / `items`, and a fetch source (`pages_url` and/or `url`).
+- Display names and descriptions for built-in entries go through
+  `displayNameKey` / `descriptionKey`. The notebooks themselves are English.
 - Install tries `pages_url` first (same-origin, works in the PWA, Android
   WebView, and Electron), then the GitHub release `url`.
 - `_fetchPackage` already has a platform cascade:
@@ -59,9 +77,8 @@ empty search stays a local, offline-capable view of the same items as today
   is therefore in the same CORS boat as the PWA, not the same boat as
   Android.
 - `test_browse_catalog.mjs` asserts the modal opens with all three sections
-  and at least 17 cards. A default language filter will hide entries unless
-  tests select “All languages” or the current kernel is one that every
-  fixture uses.
+  and at least 17 cards. With the rules below, that still holds: empty
+  search + default filters = the current list.
 
 ## UI
 
@@ -73,22 +90,27 @@ the everyday controls; Sources is a panel you push/pop in the same dialog.
 │ One-click install packages, bundles, and workbooks. │
 │                                                     │
 │ [ Search packages, bundles, workbooks… ]  [Sources] │
-│ Language: [ Python            v ]                   │
+│ Spoken language: [ 日本語                 v ]       │
+│ Kernel:          [ All                    v ]       │
 │                                                     │
 │ Packages                                            │
-│   UnifyWeaver SciREPL          prolog, python  [✓]  │
+│   UnifyWeaver SciREPL     prolog, python  EN  [✓]   │
 │ Bundles                                             │
-│   … only if they include Python …                   │
+│   UnifyWeaver Tutorials…  4 workbooks     EN  [Install]
 │ Workbooks                                           │
-│   Life Expectancy Analysis     python, r      [Install]
-│   Compute Pi …                 python         [Install]
-│   Tidyverse Data Wrangling     python, r      [Install]
+│   Life Expectancy Analysis  python, r     EN  [Install]
+│   …every built-in card, same as today…              │
 └─────────────────────────────────────────────────────┘
 ```
 
-With Python selected and an empty search, Prolog-only and R-only cards
-disappear. That is the filter working, not a different catalog. **All
-languages** restores today’s full list in one tap.
+After typing a query, with spoken language still 日本語:
+
+```
+│ Workbooks                                           │
+│   Compute Pi …            python          EN  [Install]  ← built-in hit
+│   円周率の計算            python          JA  [Install]  ← source hit
+│     example/scirepl-workbooks                       │
+```
 
 Sources panel (same modal, back chevron):
 
@@ -108,32 +130,80 @@ Sources panel (same modal, back chevron):
 └──────────────────────────────────────────────────────┘
 ```
 
-### Language filter rules
+On a narrow phone the two selects wrap under the search row. Labels must
+use the existing senses so translators do not collapse them: spoken
+language is `Language-Interface`, kernel is `Language-Programming`.
+Endonyms in the spoken-language dropdown come from `i18n/manifest.json`
+(`日本語`, `Deutsch`, `English`, …), not from English names.
 
-- Options: **All languages**, then every kernel in `#lang-selector`
-  (python, prolog, bash, javascript, r, lua, typr, clojurescript).
-- On open, set the filter to `kernelManager.currentLanguage`. Changing the
-  editor language while the modal is already open does **not** retarget the
-  filter; reopening does.
-- An entry matches when `kernels` is missing, or contains the selected
-  kernel. Multi-kernel workbooks (python+r) show for either kernel.
+### Spoken-language filter (defaults to the app locale)
+
+- Options: **All spoken languages**, then every locale in the i18n
+  manifest that the app is willing to activate (same usability rule as
+  `i18n.resolve()`: complete enough, reviewed or drafts-shown).
+- On open, set the filter to `window.i18n.current`. Changing the app
+  locale while the modal is already open does **not** retarget the
+  filter; reopening does. Listen to `i18n:changed` only to relabel the
+  chrome, not to override a choice the user already made in the dropdown.
+- This filter does **not** hide built-in curated entries. Those are the
+  default view. Their titles and descriptions are already translated;
+  their notebook bodies are English and stay English.
+- It **does** scope extra items from catalog sources. A source item
+  matches when its `locales` list (see [Catalog index format](#catalog-index-format))
+  includes the selected locale, or shares the primary subtag (`pt-BR`
+  matches `pt`; `zh` matches `zh-Hans` only if we store the primary
+  subtag — keep matching simple: equal code, or equal `code.split('-')[0]`).
+- Missing `locales` on an item means `['en']`. English is the content
+  language of everything we ship today.
+- **All spoken languages** makes search return source hits in every
+  locale. Use that when you are hunting for a title you saw in another
+  language.
+- Persist the last explicit spoken-language choice? No. Always
+  re-default to `i18n.current` on open, so the control tracks the app,
+  not a hidden setting.
+
+### Programming-language filter (defaults to All)
+
+- Options: **All**, then every kernel in `#lang-selector` (python, prolog,
+  bash, javascript, r, lua, typr, clojurescript).
+- Default **All**, so first-open still shows Prolog workbooks when the
+  editor is on Python. That is the “same defaults” constraint.
+- A one-tap “This kernel” chip (the current `#lang-selector` value) is
+  worth adding if the two-select toolbar feels like too many steps to
+  get to “Python only”. It is not the default.
+- An entry matches All, or when `kernels` is missing, or when `kernels`
+  contains the selected kernel. Multi-kernel workbooks (python+r) match
+  either kernel.
 - A bundle matches if its own `kernels` matches, or if any of its `items`
-  would match. Showing a bundle that then installs hidden Prolog workbooks
-  is acceptable; the bundle card already lists what it contains.
+  would match. Showing a bundle that then installs a Prolog workbook the
+  kernel filter would have hidden is acceptable; the bundle card already
+  lists what it contains.
 - Empty sections omit their header (already true).
-- Persist the last **explicit** choice? No. Always re-default to the
-  current kernel on open, so the control stays a view over “what I am
-  writing now”, not a hidden setting.
+- Changing the editor kernel while the modal is open does not retarget
+  this filter either.
+
+### Content-locale badge
+
+When the card’s content locale is not the same as the spoken-language
+filter (or, if the filter is All, not the same as `i18n.current`), show a
+short badge (`EN`, `JA`, `PT-BR`). Japanese UI + English built-in
+workbook → `EN`. That is honest without hiding the card.
+
+Skip the badge when they match, so a Japanese source hit in a Japanese
+UI is not noisy.
 
 ### Search rules
 
-- Filter name, description, id, kernel ids, and bundle contents.
+- Filter name, description, id, kernel ids, bundle contents, and locale
+  codes / endonyms.
 - Case-insensitive substring is enough for v1. No fuzzy ranking.
-- Empty query: built-in entries only (after language filter). **Do not**
-  show remote-source items, and **do not** fetch remote indexes.
-- Non-empty query: union of built-in matches and enabled-source matches.
-  Fetch each enabled source the first time a query is run this session
-  (then keep it in memory). A Sources “Retry” / toggle-on also fetches.
+- Empty query: built-in entries only, after the **kernel** filter.
+  Spoken language does not hide them. **Do not** show remote-source
+  items, and **do not** fetch remote indexes.
+- Non-empty query: union of built-in matches and enabled-source matches
+  that pass both filters. Fetch each enabled source the first time a
+  query is run this session (then keep it in memory). A Sources “Retry”
+  / toggle-on also fetches.
 - Built-in hits stay at the top of each section; source hits follow, with
   a small origin label (`user/workbooks`) so it is obvious they are not
   curated.
@@ -162,15 +232,17 @@ can consume remote items without a second type.
 ```json
 {
   "format_version": "1.0",
-  "name": "Example workbooks",
+  "name": "日本語ワークブック",
   "source": "https://github.com/example/scirepl-workbooks",
+  "locales": ["ja"],
   "items": [
     {
       "id": "example-pi",
-      "name": "Compute Pi",
-      "description": "Archimedean bounds notebook.",
+      "name": "円周率の計算",
+      "description": "アルキメデスの上下界で円周率を挟むノートブック。",
       "type": "workbook",
       "kernels": ["python"],
+      "locales": ["ja"],
       "url": "https://raw.githubusercontent.com/example/scirepl-workbooks/main/pi.srwb",
       "size": "~6 KB",
       "revision": 1,
@@ -184,16 +256,29 @@ Rules for remote items:
 
 - `id` must be unique **within that source**. The app namespaces as
   `sourceId:itemId` so two repos can both ship `intro`.
-- `url` is the installable artifact. For the PWA it must be a CORS-open
-  HTTPS URL (see below). `pages_url` on a remote item is only useful if it
-  is same-origin with the running app, which community repos will not be.
+- `locales` is the **content** language of the notebook or package, BCP 47
+  tags from the same set the app uses (`en`, `ja`, `pt-BR`, …). It is not
+  the kernel. A bilingual notebook lists both (`["en", "ja"]`) and matches
+  either spoken-language filter.
+- Index-level `locales` is the default for items that omit the field.
+  Item-level wins. If both are missing, treat as `["en"]`.
+- `name` / `description` are in the content language. v1 does not take
+  per-locale maps (`{ "en": "…", "ja": "…" }`). A second-language edition
+  is a second item (or a second source), not a parallel string table.
 - No `displayNameKey` / i18n keys from remote JSON. Remote text is shown
   as authored. The chrome (Search, Sources, section headers, errors)
   stays in the i18n catalogues.
+- `url` is the installable artifact. For the PWA it must be a CORS-open
+  HTTPS URL (see below). `pages_url` on a remote item is only useful if it
+  is same-origin with the running app, which community repos will not be.
 - Ignore unknown fields. Reject the whole index if `format_version` is
   newer than we understand, and say so in `lastError`.
 - Cap index size (e.g. 500 items / 1 MB JSON) so a huge file cannot stall
   a phone.
+
+Built-in entries should grow an explicit `locales: ['en']` when this
+ships, even though the filter will not hide them. That feeds the badge
+and keeps the schema one shape.
 
 ### Resolving a GitHub repo URL
 
@@ -280,8 +365,9 @@ in this design-only PR:
 Empty-search Browse must not hit the network. That keeps the default view
 honest offline and avoids a surprise request on every menu open.
 
-Do not probe sources in the background. Do not send the search string to
-any server; filtering is local against indexes the user enabled.
+Do not probe sources in the background. Do not send the search string, the
+spoken-language filter, or the kernel filter to any server; filtering is
+local against indexes the user enabled.
 
 ## Trust
 
@@ -302,45 +388,60 @@ sends a huge `Content-Length`, abort).
 - Auto-adding community repos. The built-in list stays the default.
 - Changing which items are in the built-in array. Search finds *more*;
   it does not demote UnifyWeaver, ggplot2, TypR, etc.
+- Hiding built-in English workbooks because the UI is in another locale.
+  Chrome is translated; content locale is a badge, not a gate, for
+  curated entries.
+- Per-locale string maps on remote items in v1.
 - An Electron or PWA CORS bypass.
-- Filtering by UI locale. “Language” here is the **kernel**, not i18n.
+- Defaulting the kernel filter to the editor language. That would hide
+  most of today’s list. Kernel defaults to All.
 
 ## Suggested implementation order
 
 Keep the comparison/filter layer pure and testable without a browser,
 same split as `docs/proposal-package-update-checks.md`.
 
-1. **Pure filter** — given entries, a query string, and a kernel id,
-   return the visible list. Unit-testable in node. Covers “empty query
-   ⇒ built-in only”, kernel membership, bundle matching, namespacing.
-2. **Catalog UI** — search input, language `<select>`, empty-state copy.
-   Wired only to the built-in array. `test_browse_catalog.mjs` must
-   select All languages (or the test kernel) before counting cards, so
-   the default-filter change does not look like a missing workbook.
+1. **Pure filter** — given entries, a query string, a spoken-language
+   code (`null` = All), a kernel id (`null` = All), and a bit that marks
+   built-in vs source, return the visible list. Unit-testable in node.
+   Covers “empty query ⇒ built-in only, locale ignored”, “non-empty ⇒
+   locale gates source items”, kernel membership, bundle matching,
+   namespacing, primary-subtag locale match.
+2. **Catalog UI** — search input, spoken-language `<select>` defaulting
+   to `i18n.current`, kernel `<select>` defaulting to All, locale badge,
+   empty-state copy. Wired only to the built-in array. First-open card
+   count must stay ≥ 17 so `test_browse_catalog.mjs` does not look like
+   a missing workbook.
 3. **Index fetch + Sources panel** — persist sources, resolve GitHub
-   repo URLs, parse `scirepl-catalog.json`, union on search. CORS
-   failures are first-class UI, not console noise.
+   repo URLs, parse `scirepl-catalog.json`, union on search with locale
+   gating. CORS failures are first-class UI, not console noise.
 4. **Install from remote hits** — reuse `_fetchPackage`. On PWA/Electron
    CORS failure, the manual-import message above. Android uses native
    HTTP as it already does.
 5. **Privacy policy** — one paragraph for user-added catalog sources,
    kept in sync with `privacy:check`.
 6. **Docs** — a short “Publishing a catalog source” section in
-   `docs/packages.md` once the JSON schema is real.
+   `docs/packages.md` once the JSON schema is real, including `locales`.
 
-Phase 2 is already a useful PR on its own (search + language filter over
-today’s list). Phase 3 is what makes search find *more*. Do not ship
+Phase 2 is already a useful PR on its own (search + both filters over
+today’s list). Phase 3 is what makes search find *more*, and what makes
+the spoken-language default do something beyond labelling. Do not ship
 Sources without the CORS error path; a button that adds a GitHub release
 URL and then fails silently on the PWA is worse than no button.
 
 ## Test notes
 
 - `test_browse_catalog.mjs` currently assumes every built-in card is
-  visible on open. After phase 2 it should assert:
-  - default filter equals the current kernel (python in the fixture);
-  - All languages restores ≥ 17 cards and the three section headers;
-  - a query that matches only a remote fixture appears only after the
-    source is enabled (phase 3, with a stub index, not live GitHub).
+  visible on open. After phase 2 it should still assert that on a stock
+  English (or any) locale with kernel = All.
+- Additional assertions:
+  - spoken-language select equals `i18n.current` on open;
+  - kernel select equals All on open;
+  - switching kernel to `lua` hides non-Lua built-in cards and All
+    restores them;
+  - a query that matches only a remote fixture tagged `ja` appears when
+    spoken language is `ja` (or All) and not when it is `en` (phase 3,
+    stub index, not live GitHub).
 - Do not hit the network in CI for source tests. Serve a tiny
   `scirepl-catalog.json` from the same origin via `server.js`.
 - A Playwright case that points at a cross-origin URL **without** CORS
@@ -348,13 +449,13 @@ URL and then fails silently on the PWA is worse than no button.
 
 ## Open questions
 
-1. **Default language vs “same defaults”.** Defaulting to the current
-   kernel *does* hide some of today’s cards (open Browse on Python, and
-   the Lua/TypR/Prolog-only workbooks are gone until you pick All). That
-   matches “filter defaults to the selected language.” If first-open
-   must be byte-for-byte the current list, default the control to All
-   and keep “Current language” as a one-tap chip instead. Recommendation:
-   default to the current kernel; All is one tap.
+1. **Should a future built-in Japanese workbook be a second catalog
+   entry, or a locale variant of an English one?** Recommendation: a
+   second entry with `locales: ['ja']`. Variants need a grouping id we
+   do not have yet, and the default view is allowed to show both (built-in
+   is never locale-gated). Search + spoken-language = `ja` would still
+   prefer the Japanese source hits by ranking them with the built-in `ja`
+   entry, not by hiding the English twin.
 2. **Should a non-empty search that matches nothing in sources still
    show built-in misses?** No. Search filters everything. Zero hits is
    allowed; keep the empty copy explicit (“No matches in the built-in
@@ -372,3 +473,8 @@ URL and then fails silently on the PWA is worse than no button.
    and must not cache mutable indexes forever. If both ship, they should
    share “fetch this HTTPS JSON with CORS/native cascade” rather than
    growing two helpers. Out of scope for the first catalog-browse PR.
+6. **Draft locales.** If the user has opted into draft UI translations,
+   should those codes appear in the spoken-language filter? Yes — the
+   filter lists the same locales the app can activate. A draft UI locale
+   with no community content just means search will not add source hits
+   until someone publishes a `locales: ['bn']` index.

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -405,15 +405,67 @@ Two surprises relative to the usual “native apps ignore CORS” intuition:
 
 1. **Electron is not Android.** `desktop/electron/security.js` treats the
    renderer as fully untrusted because the JavaScript kernel (and Scittle,
-   Fengari, Pyodide’s JS bridge) share `window`. There is no privileged
-   “download this URL” channel, on purpose. Adding one for catalog sources
-   would be reachable from notebook code. **Do not add it for this feature.**
-   Electron stays on the PWA fetch rules.
+   Fengari, Pyodide's JS bridge) share `window`. There is no privileged
+   "download this URL" channel, on purpose. Adding one for catalog sources
+   would be reachable from notebook code. **Do not add a general one for
+   this feature.** Electron stays on the PWA fetch rules until the
+   allowlist-scoped channel below ships.
 2. **The PWA cannot grow a proxy** without becoming a hosted backend, which
    SciREPL is not. Extending `server.js` `/proxy` helps local development
    only. It does not help `*.github.io` installs, F-Droid WebView builds
    that load Pages, or a service-worker-cached PWA opened from the home
-   screen.
+   screen. (Locally serving the PWA is still a supported power-user
+   configuration — see "Local escape hatches" below.)
+
+### Planned: Electron allowlist fetch channel
+
+A follow-up change (not the first catalog PR) adds a narrow fetch channel
+in the Electron main process: the renderer passes a URL, the main process
+fetches it — no CORS outside a renderer — and returns the bytes. The
+channel is constrained by **destination**, not by caller:
+
+- Default allowlist, **on by default**: `github.com`,
+  `raw.githubusercontent.com`, `objects.githubusercontent.com`,
+  `cdn.jsdelivr.net`. This covers catalog indexes, community workbooks on
+  raw/jsDelivr, and GitHub Releases assets.
+- A settings toggle can **disable the channel entirely**. The allowlist
+  itself is a frozen constant in the main process, **not**
+  renderer-editable: a renderer-writable allowlist would be expanded by
+  the very notebook code the boundary exists to contain.
+- This is safe to expose even though notebook code shares `window` with
+  the UI, because the filter does not need to distinguish UI code from
+  notebook code. `security.js` warns that a *caller* filter is
+  impossible; a *destination* filter is not. The worst a hostile notebook
+  can do through it is download public files from GitHub — which it can
+  already do for raw/jsDelivr via ordinary CORS-open `fetch`.
+- Same hygiene rules as everywhere else: HTTPS only, no credential-bearing
+  URLs, refuse redirects off the allowlist, cap response size, no dynamic
+  IPC dispatch (extend `ipc.js`'s explicit channel list).
+
+Once it ships, Electron joins Android as a low-friction path for
+GitHub-hosted content, and the Electron row in the matrix above becomes
+"Yes (allowlisted fetch channel)" for the GitHub columns. The channel is
+an app capability, not catalog-specific: anything that installs over
+HTTPS from GitHub benefits.
+
+### Local escape hatches (no app changes needed)
+
+Two user-run options already exist or ship with this proposal:
+
+- **Serve the PWA locally.** `npm run serve` puts the app and the dev
+  `/proxy` on the same localhost origin, so GitHub release installs work.
+  This is a legitimate end-user configuration for technical users — while
+  the PWA is not hosted anywhere, it is the *primary* PWA distribution
+  channel. A server you control can also serve genuinely custom content:
+  front a private API (keys stay server-side), or publish a local
+  `scirepl-catalog.json` that never touches GitHub.
+- **Local fetch helper.** `tools/local-fetch-helper/local-fetch-helper.mjs`
+  is a zero-dependency Node script that re-serves arbitrary HTTPS URLs
+  with CORS and Private-Network-Access headers on `127.0.0.1`. It
+  generalizes the dev `/proxy` beyond GitHub Releases and works for a
+  *hosted* PWA too. Setup and security trade-offs:
+  `docs/local-fetch-helper.md`. Same sidecar pattern as UnifyWeaver's
+  HTTP CLI server.
 
 ### Practical consequence for source authors
 
@@ -440,7 +492,8 @@ still do it, and offer the existing manual path:
 
 > This file is on a host the browser will not read (cross-origin). On
 > Android it would download directly. Elsewhere, download it yourself and
-> use Menu → Import Package.
+> use Menu → Import Package — or run the local fetch helper, see
+> docs/local-fetch-helper.md.
 
 Sources that fail at **index** fetch get a Retry on the Sources panel, not
 a modal.
@@ -488,7 +541,9 @@ sends a huge `Content-Length`, abort).
 - Seeding fallbacks from `navigator.languages`. Initialize to English
   only. Extra languages are an explicit user choice.
 - Per-locale string maps on remote items in v1.
-- An Electron or PWA CORS bypass.
+- A general-purpose Electron or PWA CORS bypass. The planned Electron
+  channel is allowlist-scoped (GitHub hosts, on by default, user can
+  disable) — not an open fetch hole, and not part of the first catalog PR.
 - Defaulting the kernel filter to the editor language. That would hide
   most of today’s list. Kernel defaults to All.
 
@@ -593,3 +648,15 @@ URL and then fails silently on the PWA is worse than no button.
    Edit panel?** Toolbar: the checkbox is the thing you toggle per
    search. Edit panel: the ordered list. Duplicating the checkbox in
    both is fine if they are the same persisted bit.
+9. **Electron allowlist channel: master toggle or per-host control?**
+   Recommendation: one master toggle in settings ("Allow the desktop app
+   to fetch from GitHub on my behalf", default on). Per-host editing
+   lives in a main-process config file for advanced users, never in
+   renderer state — anything the renderer can write, notebook code can
+   write. The disable path must also cover installs already in flight.
+10. **Should the app detect a running local fetch helper?** A one-time
+    `GET http://127.0.0.1:8787/health` probe on CORS failure (not on every
+    open) would let the error message upgrade itself from "download it
+    yourself" to "your helper is running — retry?" Probing localhost from
+    a hosted page is a private-network request, so expect a preflight;
+    the helper already answers it. Keep the probe failure silent.

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -201,8 +201,15 @@ Japanese, the chain is `['ja', 'en']`.
   off.
 - Duplicate codes are illegal; adding a locale that is already primary or
   already a fallback is a no-op.
-- Only codes the app can activate are addable (same list as the primary
-  dropdown, minus All).
+- The **fallback Add list is wider than the primary dropdown.** Primary is
+  an interface-locale choice, so it lists only manifest locales. Fallbacks
+  are a *content* preference: addable codes are the manifest set **plus**
+  any BCP 47 tag declared by an enabled source's items. Content language
+  is not UI language — a Korean workbook should not have to wait for a
+  Korean UI translation before `ko` can be a fallback. The Add picker
+  groups these as "interface languages" and "languages from your
+  sources". A free-text code is not allowed; the code must come from a
+  known set so matching and endonym labels stay well-defined.
 - This filter does **not** hide built-in curated entries on **empty
   search**. Those are the default view. Their titles and descriptions are
   already translated; their notebook bodies are English and stay English.
@@ -316,6 +323,26 @@ hit in a Japanese UI is not noisy.
   primitive. Repo paste is sugar over that.
 - Removing a source does not uninstall anything already imported.
 
+### Source index caching
+
+"Fetch on first search of the session" needs a staleness policy, because
+indexes resolved through mutable refs (`@HEAD`, `main`) change under the
+same URL:
+
+- Fetched indexes are held in memory for the session **and** persisted
+  (with `lastFetchedAt`) so a second search session does not re-fetch
+  immediately.
+- A persisted index is re-fetched when it is older than **24 hours**, when
+  the user taps **Retry** or toggles the source on, or when the source URL
+  is re-added. Send `If-None-Match` / `If-Modified-Since` when the
+  previous response carried an ETag/Last-Modified, so a fresh-but-
+  unchanged index is cheap.
+- Never cache a mutable-ref index past the TTL "just in case": a catalog
+  that silently goes weeks stale is how "update available" badges lie.
+- If a re-fetch fails, keep the last good index, mark it stale in the
+  Sources panel ("last fetched 9 days ago — refresh failed"), and rank its
+  items normally. A failed refresh must not make a source's items vanish.
+
 ## Catalog index format
 
 Keep it aligned with the in-app entry schema so `_renderCard` / `_install`
@@ -337,6 +364,7 @@ can consume remote items without a second type.
       "locales": ["ja"],
       "url": "https://raw.githubusercontent.com/example/scirepl-workbooks/main/pi.srwb",
       "size": "~6 KB",
+      "sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       "revision": 1,
       "format": "srwb"
     }
@@ -349,10 +377,11 @@ Rules for remote items:
 - `id` must be unique **within that source**. The app namespaces as
   `sourceId:itemId` so two repos can both ship `intro`.
 - `locales` is the **content** language of the notebook or package, BCP 47
-  tags from the same set the app uses (`en`, `ja`, `pt-BR`, …). It is not
-  the kernel. A bilingual notebook lists both (`["en", "ja"]`) and takes
-  the best slot on the user’s preference chain (Japanese primary ranks it
-  as Japanese, not as an English fallback).
+  tags (`en`, `ja`, `pt-BR`, …). The set is not limited to the app's
+  interface locales — sources can publish content in languages the UI
+  does not ship. It is not the kernel. A bilingual notebook lists both
+  (`["en", "ja"]`) and takes the best slot on the user’s preference chain
+  (Japanese primary ranks it as Japanese, not as an English fallback).
 - Index-level `locales` is the default for items that omit the field.
   Item-level wins. If both are missing, treat as `["en"]`.
 - `name` / `description` are in the content language. v1 does not take
@@ -364,6 +393,19 @@ Rules for remote items:
 - `url` is the installable artifact. For the PWA it must be a CORS-open
   HTTPS URL (see below). `pages_url` on a remote item is only useful if it
   is same-origin with the running app, which community repos will not be.
+- `sha256` (optional, **recommended**) is the lowercase hex SHA-256 of the
+  artifact bytes. When present, the app verifies the download before
+  install and refuses on mismatch. When absent, the install proceeds but
+  the card and the confirmation show an "unverified content" note.
+  Rationale: a source URL is entered once and then re-fetched silently,
+  and installed notebooks and package wrappers are *executed* — HTTPS
+  alone does not cover a compromised source repo or a poisoned CDN cache
+  between the day the user added the source and the day they install.
+- `revision` is a source-local, monotonically increasing integer. The app
+  compares it against the installed copy to badge "update available";
+  it carries no cross-source meaning. Bumping `revision` without
+  changing `sha256` (when both are present) is treated as an index
+  error, not an update.
 - Ignore unknown fields. Reject the whole index if `format_version` is
   newer than we understand, and say so in `lastError`.
 - Cap index size (e.g. 500 items / 1 MB JSON) so a huge file cannot stall
@@ -525,6 +567,14 @@ visible on every remote card.
 Refuse to follow redirects off HTTPS. Cap download size with the same
 instinct as package install (show `size` from the index; if the host
 sends a huge `Content-Length`, abort).
+
+Verify `sha256` after download when the index provides it, and treat a
+mismatch as a hard install failure that names the source — a mismatch
+means the index and the artifact disagree, which is exactly what a
+compromised repo or poisoned cache looks like. Items without `sha256`
+are installable but labelled unverified; source authors should be told,
+in the publishing docs, that omitting it caps their users' trust at
+"whatever the host served today".
 
 ## What we are not doing
 

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -11,7 +11,9 @@ curated list as the **default view**, then adding:
 1. A search field that can surface **additional** items, not just filter the
    defaults.
 2. A **spoken-language** filter (interface / content locale) that **defaults
-   to the app’s current locale** (`i18n.current`).
+   to the app’s current locale** (`i18n.current`), plus an ordered **fallback
+   list** (initialized to English) and a control for whether fallbacks are
+   allowed.
 3. A **programming-language** filter (kernel) as a second control, defaulting
    to All so the first-open list stays the same as today.
 4. A Sources panel for **catalog index URLs** (typically GitHub repos that
@@ -21,7 +23,9 @@ The two “language” controls are different senses. The i18n catalogues
 already keep them apart (`Language-Interface` vs `Language-Programming` in
 `www/i18n/manifest.json`). The first draft of this note used the kernel for
 the default filter; that was the wrong sense. Spoken language is the one
-that should follow the app. Kernel is optional extra narrowing.
+that should follow the app. Kernel is optional extra narrowing. Fallbacks
+are how a Japanese UI still finds English community workbooks without
+making English the only language that exists.
 
 The hard part is still not the UI. It is where extra items live, and which
 platforms can fetch them. SciREPL has no production backend. The `/proxy`
@@ -37,11 +41,12 @@ depend on the network and on CORS.
 
 Search should **widen** the pool, not replace it:
 
-| Search box | Spoken language | What you see |
-| --- | --- | --- |
-| Empty | app locale (default) | Built-in curated entries, same as today. Kernel filter only if the user changed it from All. |
-| Non-empty | app locale (default) | Built-in matches **plus** source matches whose **content locale** includes the selected spoken language |
-| Non-empty | All spoken languages | Built-in matches plus source matches in any locale |
+| Search box | Spoken language | Fallbacks | What you see |
+| --- | --- | --- | --- |
+| Empty | app locale (default) | n/a | Built-in curated entries, same as today. Kernel filter only if the user changed it from All. |
+| Non-empty | app locale (default) | on (English) | Built-in matches **plus** source matches in the primary locale, then English (and any other configured fallbacks), ranked in preference order |
+| Non-empty | app locale | off | Built-in matches **plus** source matches in the primary locale only |
+| Non-empty | All spoken languages | ranking only | Built-in matches plus source matches in any locale, still sorted by the preference list |
 
 Typing a query is what justifies extra network work. Opening Browse with an
 empty search stays a local, offline-capable view of the same items as today.
@@ -50,9 +55,13 @@ That split also resolves the locale mismatch in the built-in catalog:
 **card chrome is translated, notebook content is English.** A Japanese UI
 still shows UnifyWeaver and ggplot2 on first open (names and descriptions
 come from `www/i18n/ja.json`). Search is how you find a Japanese-language
-workbook from a source you added. The spoken-language filter is the default
-scope for that wider pool, not a knife that cuts the curated list down to
-whatever happens to be authored in `ja`.
+workbook from a source you added. With fallbacks on (the default), an
+English community hit still appears, below the Japanese ones. With
+fallbacks off, search is strict: Japanese content only.
+
+The spoken-language filter is the default scope for that wider pool, not a
+knife that cuts the curated list down to whatever happens to be authored
+in `ja`.
 
 ## Current behaviour (the baseline we must not regress)
 
@@ -91,6 +100,7 @@ the everyday controls; Sources is a panel you push/pop in the same dialog.
 │                                                     │
 │ [ Search packages, bundles, workbooks… ]  [Sources] │
 │ Spoken language: [ 日本語                 v ]       │
+│ Fallbacks: [x] then English                    [Edit]│
 │ Kernel:          [ All                    v ]       │
 │                                                     │
 │ Packages                                            │
@@ -103,14 +113,17 @@ the everyday controls; Sources is a panel you push/pop in the same dialog.
 └─────────────────────────────────────────────────────┘
 ```
 
-After typing a query, with spoken language still 日本語:
+After typing a query, with spoken language still 日本語 and fallbacks on:
 
 ```
 │ Workbooks                                           │
-│   Compute Pi …            python          EN  [Install]  ← built-in hit
-│   円周率の計算            python          JA  [Install]  ← source hit
+│   円周率の計算            python          JA  [Install]  ← source, primary
 │     example/scirepl-workbooks                       │
+│   Compute Pi …            python          EN  [Install]  ← built-in, fallback
 ```
+
+Same query, fallbacks off: Compute Pi disappears (English content, not
+Japanese). The empty-search view still showed it; search is stricter.
 
 Sources panel (same modal, back chevron):
 
@@ -130,37 +143,107 @@ Sources panel (same modal, back chevron):
 └──────────────────────────────────────────────────────┘
 ```
 
-On a narrow phone the two selects wrap under the search row. Labels must
-use the existing senses so translators do not collapse them: spoken
-language is `Language-Interface`, kernel is `Language-Programming`.
-Endonyms in the spoken-language dropdown come from `i18n/manifest.json`
-(`日本語`, `Deutsch`, `English`, …), not from English names.
+On a narrow phone the selects wrap under the search row. Labels must use
+the existing senses so translators do not collapse them: spoken language
+is `Language-Interface`, kernel is `Language-Programming`. Endonyms in
+the spoken-language dropdown and the fallback editor come from
+`i18n/manifest.json` (`日本語`, `Deutsch`, `English`, …), not from
+English names.
+
+**Edit** opens a short ordered-list panel (push/pop in the same modal, like
+Sources). It is the only place you add, remove, or reorder fallbacks.
+
+```
+┌ ‹ Fallback languages ───────────────────────────── × ┐
+│ [x] Allow fallbacks                                  │
+│                                                      │
+│ 1. English                                    [↑][–] │
+│ [ Add language…                              v ]     │
+│                                                      │
+│ When a workbook is not in 日本語, show the next      │
+│ language on this list. English is the starting       │
+│ fallback; you can add more or turn fallbacks off.    │
+└──────────────────────────────────────────────────────┘
+```
 
 ### Spoken-language filter (defaults to the app locale)
 
-- Options: **All spoken languages**, then every locale in the i18n
+Two pieces, not one dropdown:
+
+| Piece | Session or persisted | Default |
+| --- | --- | --- |
+| **Primary** (the spoken-language select) | Session. Reset on each open. | `i18n.current` |
+| **Fallbacks** (ordered list) + **Allow fallbacks** | Persisted in `localStorage` | `fallbacks: ['en']`, `allowFallbacks: true` |
+
+Effective preference order is:
+
+```
+[primary, ...fallbacks.filter(code => code !== primary)]
+```
+
+If the UI is already English, that collapses to `['en']` and the fallback
+toggle is a no-op until the user picks another primary. If the UI is
+Japanese, the chain is `['ja', 'en']`.
+
+- Primary options: **All spoken languages**, then every locale in the i18n
   manifest that the app is willing to activate (same usability rule as
   `i18n.resolve()`: complete enough, reviewed or drafts-shown).
-- On open, set the filter to `window.i18n.current`. Changing the app
-  locale while the modal is already open does **not** retarget the
-  filter; reopening does. Listen to `i18n:changed` only to relabel the
-  chrome, not to override a choice the user already made in the dropdown.
-- This filter does **not** hide built-in curated entries. Those are the
-  default view. Their titles and descriptions are already translated;
-  their notebook bodies are English and stay English.
-- It **does** scope extra items from catalog sources. A source item
-  matches when its `locales` list (see [Catalog index format](#catalog-index-format))
-  includes the selected locale, or shares the primary subtag (`pt-BR`
-  matches `pt`; `zh` matches `zh-Hans` only if we store the primary
-  subtag — keep matching simple: equal code, or equal `code.split('-')[0]`).
-- Missing `locales` on an item means `['en']`. English is the content
-  language of everything we ship today.
-- **All spoken languages** makes search return source hits in every
-  locale. Use that when you are hunting for a title you saw in another
-  language.
-- Persist the last explicit spoken-language choice? No. Always
-  re-default to `i18n.current` on open, so the control tracks the app,
-  not a hidden setting.
+- On open, set primary to `window.i18n.current`. Changing the app locale
+  while the modal is already open does **not** retarget primary; reopening
+  does. Listen to `i18n:changed` only to relabel the chrome, not to
+  override a choice the user already made in the dropdown.
+- Fallbacks are independent of primary. Switching the dropdown from
+  Japanese to French yields `[fr, en]` when the stored fallbacks are
+  `['en']`. The previous primary is not automatically inserted into the
+  fallback list.
+- English is removable. The initial value is English, not a pinned slot.
+  An empty fallback list with Allow fallbacks on behaves like fallbacks
+  off.
+- Duplicate codes are illegal; adding a locale that is already primary or
+  already a fallback is a no-op.
+- Only codes the app can activate are addable (same list as the primary
+  dropdown, minus All).
+- This filter does **not** hide built-in curated entries on **empty
+  search**. Those are the default view. Their titles and descriptions are
+  already translated; their notebook bodies are English and stay English.
+- On **search**, locale matching applies to built-in and source items
+  alike. That is what makes “fallbacks off” mean something for a Japanese
+  user who does not want English notebooks in the results.
+- **All spoken languages** disables filtering. The preference list is
+  still used to **rank** (primary hits first, then each fallback, then
+  everything else). The Allow fallbacks toggle does not hide anything in
+  this mode; it only affects sort. Show the toggle as ranking-only, or
+  disable it, so it is not a trap.
+
+Matching an item against the chain:
+
+1. Take the item’s `locales` (missing ⇒ `['en']`).
+2. A locale on the item matches a preference slot on exact code, or on
+   equal `code.split('-')[0]` (`pt-BR` matches `pt`). Exact wins over
+   primary-subtag when ranking the same slot.
+3. The item’s **rank** is the lowest (best) preference index that matched.
+   Unmatched items are excluded unless primary is All, in which they sort
+   after every listed language.
+4. If Allow fallbacks is off, only index 0 (primary) is eligible, except
+   when primary is All (see above).
+
+Bilingual items (`locales: ['en', 'ja']`) match whichever slot is best.
+A Japanese-primary user with English fallback ranks that item as
+Japanese, not as a fallback.
+
+Do not persist the primary dropdown. Always re-default it to
+`i18n.current` on open so it tracks the app. Do persist fallbacks and
+Allow fallbacks: those are a preference, not a view over “the language I
+am using right now”.
+
+Stored shape:
+
+```json
+{
+  "allowFallbacks": true,
+  "fallbacks": ["en"]
+}
+```
 
 ### Programming-language filter (defaults to All)
 
@@ -184,29 +267,34 @@ Endonyms in the spoken-language dropdown come from `i18n/manifest.json`
 
 ### Content-locale badge
 
-When the card’s content locale is not the same as the spoken-language
-filter (or, if the filter is All, not the same as `i18n.current`), show a
-short badge (`EN`, `JA`, `PT-BR`). Japanese UI + English built-in
-workbook → `EN`. That is honest without hiding the card.
+When the card’s best matching content locale is not the **primary**
+spoken language (or, if primary is All, not `i18n.current`), show a short
+badge (`EN`, `JA`, `PT-BR`). Japanese primary + English built-in workbook
+→ `EN`. A fallback hit is exactly the case the badge is for.
 
-Skip the badge when they match, so a Japanese source hit in a Japanese
-UI is not noisy.
+Skip the badge when the best match is the primary, so a Japanese source
+hit in a Japanese UI is not noisy.
 
 ### Search rules
 
 - Filter name, description, id, kernel ids, bundle contents, and locale
   codes / endonyms.
-- Case-insensitive substring is enough for v1. No fuzzy ranking.
+- Case-insensitive substring is enough for v1.
+- Rank by (1) preference-list index (primary, then each fallback), (2)
+  exact locale match before primary-subtag match, (3) built-in before
+  source, (4) original catalog order. Do not invent a text-relevance
+  score in v1.
 - Empty query: built-in entries only, after the **kernel** filter.
-  Spoken language does not hide them. **Do not** show remote-source
-  items, and **do not** fetch remote indexes.
+  Spoken language and fallbacks do not hide them. **Do not** show
+  remote-source items, and **do not** fetch remote indexes.
 - Non-empty query: union of built-in matches and enabled-source matches
-  that pass both filters. Fetch each enabled source the first time a
-  query is run this session (then keep it in memory). A Sources “Retry”
-  / toggle-on also fetches.
-- Built-in hits stay at the top of each section; source hits follow, with
-  a small origin label (`user/workbooks`) so it is obvious they are not
-  curated.
+  that pass kernel + spoken-language (with fallbacks as above). Fetch
+  each enabled source the first time a query is run this session (then
+  keep it in memory). A Sources “Retry” / toggle-on also fetches.
+- Source hits still carry a small origin label (`user/workbooks`) so it
+  is obvious they are not curated. Built-in-first is only a tiebreaker
+  inside the same preference slot: a Japanese source hit outranks an
+  English built-in hit when primary is `ja`.
 - Offline / CORS failure on a source: keep built-in results, show one
   non-blocking line under the toolbar (“2 sources unavailable”). Never
   empty the default catalog because a remote index failed.
@@ -258,8 +346,9 @@ Rules for remote items:
   `sourceId:itemId` so two repos can both ship `intro`.
 - `locales` is the **content** language of the notebook or package, BCP 47
   tags from the same set the app uses (`en`, `ja`, `pt-BR`, …). It is not
-  the kernel. A bilingual notebook lists both (`["en", "ja"]`) and matches
-  either spoken-language filter.
+  the kernel. A bilingual notebook lists both (`["en", "ja"]`) and takes
+  the best slot on the user’s preference chain (Japanese primary ranks it
+  as Japanese, not as an English fallback).
 - Index-level `locales` is the default for items that omit the field.
   Item-level wins. If both are missing, treat as `["en"]`.
 - `name` / `description` are in the content language. v1 does not take
@@ -366,8 +455,8 @@ Empty-search Browse must not hit the network. That keeps the default view
 honest offline and avoids a surprise request on every menu open.
 
 Do not probe sources in the background. Do not send the search string, the
-spoken-language filter, or the kernel filter to any server; filtering is
-local against indexes the user enabled.
+spoken-language filter, the fallback list, or the kernel filter to any
+server; filtering is local against indexes the user enabled.
 
 ## Trust
 
@@ -388,9 +477,12 @@ sends a huge `Content-Length`, abort).
 - Auto-adding community repos. The built-in list stays the default.
 - Changing which items are in the built-in array. Search finds *more*;
   it does not demote UnifyWeaver, ggplot2, TypR, etc.
-- Hiding built-in English workbooks because the UI is in another locale.
-  Chrome is translated; content locale is a badge, not a gate, for
-  curated entries.
+- Hiding built-in English workbooks on **empty search** because the UI is
+  in another locale. Chrome is translated; content locale is a badge, not
+  a gate, for the curated default view. Search *does* apply locale +
+  fallbacks to built-in items.
+- Seeding fallbacks from `navigator.languages`. Initialize to English
+  only. Extra languages are an explicit user choice.
 - Per-locale string maps on remote items in v1.
 - An Electron or PWA CORS bypass.
 - Defaulting the kernel filter to the editor language. That would hide
@@ -401,20 +493,25 @@ sends a huge `Content-Length`, abort).
 Keep the comparison/filter layer pure and testable without a browser,
 same split as `docs/proposal-package-update-checks.md`.
 
-1. **Pure filter** — given entries, a query string, a spoken-language
-   code (`null` = All), a kernel id (`null` = All), and a bit that marks
-   built-in vs source, return the visible list. Unit-testable in node.
-   Covers “empty query ⇒ built-in only, locale ignored”, “non-empty ⇒
-   locale gates source items”, kernel membership, bundle matching,
-   namespacing, primary-subtag locale match.
+1. **Pure filter** — given entries, a query string, a primary locale
+   (`null` = All), `allowFallbacks`, an ordered fallback list, a kernel
+   id (`null` = All), and a bit that marks built-in vs source, return the
+   visible list in rank order. Unit-testable in node. Covers “empty query
+   ⇒ built-in only, locale ignored”, “non-empty + fallbacks on ⇒ primary
+   then English”, “non-empty + fallbacks off ⇒ primary only”, kernel
+   membership, bundle matching, namespacing, primary-subtag locale match,
+   bilingual items taking the best slot, English primary collapsing the
+   chain to `['en']`.
 2. **Catalog UI** — search input, spoken-language `<select>` defaulting
-   to `i18n.current`, kernel `<select>` defaulting to All, locale badge,
-   empty-state copy. Wired only to the built-in array. First-open card
-   count must stay ≥ 17 so `test_browse_catalog.mjs` does not look like
-   a missing workbook.
+   to `i18n.current`, Allow fallbacks checkbox, fallback summary (“then
+   English”) + Edit panel, kernel `<select>` defaulting to All, locale
+   badge, empty-state copy. Wired only to the built-in array. First-open
+   card count must stay ≥ 17 so `test_browse_catalog.mjs` does not look
+   like a missing workbook.
 3. **Index fetch + Sources panel** — persist sources, resolve GitHub
    repo URLs, parse `scirepl-catalog.json`, union on search with locale
-   gating. CORS failures are first-class UI, not console noise.
+   gating and preference ranking. CORS failures are first-class UI, not
+   console noise.
 4. **Install from remote hits** — reuse `_fetchPackage`. On PWA/Electron
    CORS failure, the manual-import message above. Android uses native
    HTTP as it already does.
@@ -436,12 +533,17 @@ URL and then fails silently on the PWA is worse than no button.
   English (or any) locale with kernel = All.
 - Additional assertions:
   - spoken-language select equals `i18n.current` on open;
+  - Allow fallbacks is on and the summary lists English when primary is
+    not `en`;
   - kernel select equals All on open;
   - switching kernel to `lua` hides non-Lua built-in cards and All
     restores them;
-  - a query that matches only a remote fixture tagged `ja` appears when
-    spoken language is `ja` (or All) and not when it is `en` (phase 3,
-    stub index, not live GitHub).
+  - a query that matches a remote fixture tagged `ja` and a built-in
+    tagged `en` lists the Japanese card first when primary is `ja` and
+    fallbacks are on, and lists only the Japanese card when fallbacks
+    are off (phase 3, stub index, not live GitHub);
+  - primary `en` with stored fallbacks `['en']` does not duplicate
+    English in the chain.
 - Do not hit the network in CI for source tests. Serve a tiny
   `scirepl-catalog.json` from the same origin via `server.js`.
 - A Playwright case that points at a cross-origin URL **without** CORS
@@ -452,14 +554,14 @@ URL and then fails silently on the PWA is worse than no button.
 1. **Should a future built-in Japanese workbook be a second catalog
    entry, or a locale variant of an English one?** Recommendation: a
    second entry with `locales: ['ja']`. Variants need a grouping id we
-   do not have yet, and the default view is allowed to show both (built-in
-   is never locale-gated). Search + spoken-language = `ja` would still
-   prefer the Japanese source hits by ranking them with the built-in `ja`
-   entry, not by hiding the English twin.
+   do not have yet, and the empty-search view is allowed to show both
+   (built-in is never locale-gated there). Search + primary `ja` ranks
+   the Japanese entry in slot 0 and the English twin in the English
+   fallback slot (or hides the twin if fallbacks are off).
 2. **Should a non-empty search that matches nothing in sources still
-   show built-in misses?** No. Search filters everything. Zero hits is
-   allowed; keep the empty copy explicit (“No matches in the built-in
-   catalog or 2 sources”).
+   show built-in misses?** No. Search filters everything, including
+   locale. Zero hits is allowed; keep the empty copy explicit (“No
+   matches in 日本語, or in fallbacks English”).
 3. **jsDelivr vs raw.githubusercontent.com as the documented author
    path.** Both work in the PWA. jsDelivr caches; raw is canonical.
    Resolve both; document raw as the file you put in the repo and
@@ -474,7 +576,16 @@ URL and then fails silently on the PWA is worse than no button.
    share “fetch this HTTPS JSON with CORS/native cascade” rather than
    growing two helpers. Out of scope for the first catalog-browse PR.
 6. **Draft locales.** If the user has opted into draft UI translations,
-   should those codes appear in the spoken-language filter? Yes — the
-   filter lists the same locales the app can activate. A draft UI locale
-   with no community content just means search will not add source hits
-   until someone publishes a `locales: ['bn']` index.
+   should those codes appear in the spoken-language filter and the
+   fallback Add list? Yes — the same locales the app can activate. A
+   draft UI locale with no community content just means search will not
+   add source hits until someone publishes a `locales: ['bn']` index.
+7. **Should `navigator.languages` seed extra fallbacks?** No for v1.
+   English is the documented starting fallback. Browser language lists
+   are noisy (often include `en-US` plus a region the user does not
+   actually read) and would surprise a Japanese user with German hits
+   because they once accepted a `de` Chrome pack.
+8. **Does Allow fallbacks belong on the catalog toolbar or only in the
+   Edit panel?** Toolbar: the checkbox is the thing you toggle per
+   search. Edit panel: the ordered list. Duplicating the checkbox in
+   both is fine if they are the same persisted bit.

--- a/docs/proposal-catalog-browse.md
+++ b/docs/proposal-catalog-browse.md
@@ -477,12 +477,37 @@ channel is constrained by **destination**, not by caller:
 - This is safe to expose even though notebook code shares `window` with
   the UI, because the filter does not need to distinguish UI code from
   notebook code. `security.js` warns that a *caller* filter is
-  impossible; a *destination* filter is not. The worst a hostile notebook
-  can do through it is download public files from GitHub — which it can
-  already do for raw/jsDelivr via ordinary CORS-open `fetch`.
+  impossible; a *destination* filter is not. To be precise about what the
+  channel adds: `github.com` release downloads and
+  `objects.githubusercontent.com` are **not** CORS-open, so this is new
+  reach for notebook code, not a no-op — the claim is that the *impact
+  class* is unchanged (reading public bytes from GitHub-operated hosts),
+  not that the capability already existed. The attacks that class
+  suggests all fail structurally:
+  - **Exfiltration via request URL** (encoding data into a path or query
+    the attacker later reads back) requires access to GitHub's or
+    jsDelivr's server logs, which an attacker does not have. The response
+    returns to the same renderer that asked; there is no side channel.
+  - **Session riding**: the main-process fetch carries no cookies and no
+    ambient GitHub credentials; there is nothing to ride.
+  - **Redirect laundering** off the allowlist is refused (below).
+  The remaining honest caveat: allowlisted hosts serve *arbitrary
+  user-published content* (any repo, any release), so the channel is a
+  transport, never an integrity boundary — `sha256` verification and the
+  unverified-content labelling apply to bytes from this channel exactly
+  as to CORS fetches.
 - Same hygiene rules as everywhere else: HTTPS only, no credential-bearing
   URLs, refuse redirects off the allowlist, cap response size, no dynamic
-  IPC dispatch (extend `ipc.js`'s explicit channel list).
+  IPC dispatch (extend `ipc.js`'s explicit channel list). Debounce or cap
+  per-session request volume so a hostile notebook cannot use the user's
+  IP to hammer GitHub.
+- **Disable control (decided; was open question 9):** one master toggle
+  in settings — "Allow the desktop app to fetch from GitHub on my
+  behalf", default on — and nothing per-host in the UI. The allowlist
+  stays a frozen constant in the main process; advanced users edit a
+  main-process config file, never renderer state, because anything the
+  renderer can write, notebook code can write. Flipping the toggle off
+  also aborts fetches already in flight.
 
 Once it ships, Electron joins Android as a low-friction path for
 GitHub-hosted content, and the Electron row in the matrix above becomes
@@ -539,6 +564,17 @@ still do it, and offer the existing manual path:
 
 Sources that fail at **index** fetch get a Retry on the Sources panel, not
 a modal.
+
+**Helper detection (decided; was open question 10):** on a CORS install
+failure — and only then, never on modal open — probe
+`GET http://127.0.0.1:8787/health` once per session. If it answers, the
+error copy upgrades to "your local fetch helper is running — retry
+through it?"; if it does not, stay silent and show the manual-import copy
+above. The probe is a private-network request from a secure page, so it
+triggers a PNA preflight; the helper answers that preflight. A probe
+failure is expected ambient state (helper not running), not an error to
+surface. Never auto-route installs through the helper without the user
+tapping the retry.
 
 ## Privacy and consent
 
@@ -699,14 +735,9 @@ URL and then fails silently on the PWA is worse than no button.
    search. Edit panel: the ordered list. Duplicating the checkbox in
    both is fine if they are the same persisted bit.
 9. **Electron allowlist channel: master toggle or per-host control?**
-   Recommendation: one master toggle in settings ("Allow the desktop app
-   to fetch from GitHub on my behalf", default on). Per-host editing
-   lives in a main-process config file for advanced users, never in
-   renderer state — anything the renderer can write, notebook code can
-   write. The disable path must also cover installs already in flight.
-10. **Should the app detect a running local fetch helper?** A one-time
-    `GET http://127.0.0.1:8787/health` probe on CORS failure (not on every
-    open) would let the error message upgrade itself from "download it
-    yourself" to "your helper is running — retry?" Probing localhost from
-    a hosted page is a private-network request, so expect a preflight;
-    the helper already answers it. Keep the probe failure silent.
+   Decided — master toggle only; see "Disable control" under "Planned:
+   Electron allowlist fetch channel".
+10. **Should the app detect a running local fetch helper?** Decided —
+    one probe per session on CORS failure, silent when absent, retry is
+    user-initiated; see "Helper detection" under "Error copy when CORS
+    blocks an install".

--- a/tools/local-fetch-helper/local-fetch-helper.mjs
+++ b/tools/local-fetch-helper/local-fetch-helper.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * local-fetch-helper.mjs — a localhost companion server for SciREPL.
+ *
+ * Fetches HTTPS URLs on behalf of the browser app and re-serves them with
+ * CORS headers, so a PWA (or Electron renderer) can install catalog items
+ * from hosts that do not send Access-Control-Allow-Origin — most notably
+ * GitHub Releases (github.com/.../releases/download/...) and other-repo
+ * GitHub Pages origins.
+ *
+ * This is the same pattern as SciREPL's dev-server /proxy and UnifyWeaver's
+ * HTTP CLI server: the browser delegates a cross-origin fetch to a local
+ * process that is not bound by CORS. The user runs it themselves, on their
+ * own machine, by choice. It is a convenience, never a requirement — the
+ * built-in catalog and CORS-open sources (raw.githubusercontent.com,
+ * cdn.jsdelivr.net) work without it.
+ *
+ * Usage:
+ *   node local-fetch-helper.mjs            # listens on 127.0.0.1:8787
+ *   PORT=9000 node local-fetch-helper.mjs
+ *
+ * Endpoints:
+ *   GET /health          -> { ok: true }
+ *   GET /fetch?url=...   -> proxied response (https:// URLs only)
+ *
+ * Security posture:
+ *   - Binds to 127.0.0.1 only. Never reachable from the LAN.
+ *   - HTTPS targets only; no credentials in URLs; max 5 redirects, and a
+ *     redirect to a non-https URL is refused.
+ *   - Response size capped (default 64 MB) to keep a hostile or broken
+ *     upstream from exhausting memory/disk.
+ *   - Sends Access-Control-Allow-Origin: * and answers Private Network
+ *     Access preflights, because that is the entire point of the helper.
+ *     Anything the machine can reach over HTTPS becomes readable by any
+ *     web page open in the local browser while this runs. Run it only
+ *     when you are installing packages, and stop it afterwards if that
+ *     trade-off makes you uncomfortable.
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+
+const PORT = Number(process.env.PORT) || 8787;
+const MAX_BYTES = Number(process.env.MAX_BYTES) || 64 * 1024 * 1024;
+const MAX_REDIRECTS = 5;
+
+function corsHeaders(extra = {}) {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': '*',
+    // Private Network Access: a public-https page (a hosted PWA) calling
+    // http://127.0.0.1 triggers a preflight that requires this header.
+    'Access-Control-Allow-Private-Network': 'true',
+    ...extra,
+  };
+}
+
+function send(res, status, body, extra = {}) {
+  res.writeHead(status, corsHeaders(extra));
+  res.end(body);
+}
+
+function isAllowedTarget(raw) {
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:') return null;
+  if (url.username || url.password) return null;
+  return url;
+}
+
+function fetchWithRedirects(url, redirectsLeft) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: { 'User-Agent': 'scirepl-local-fetch-helper/1.0' } }, (upstream) => {
+      const code = upstream.statusCode || 0;
+      if (code >= 300 && code < 400 && upstream.headers.location) {
+        upstream.resume(); // drain so the socket can be reused
+        if (redirectsLeft <= 0) {
+          reject(new Error('Too many redirects'));
+          return;
+        }
+        const next = isAllowedTarget(new URL(upstream.headers.location, url).toString());
+        if (!next) {
+          reject(new Error('Refused redirect to a non-https or credential-bearing URL'));
+          return;
+        }
+        resolve(fetchWithRedirects(next, redirectsLeft - 1));
+        return;
+      }
+      resolve(upstream);
+    });
+    req.on('error', reject);
+    req.setTimeout(30_000, () => req.destroy(new Error('Upstream timed out')));
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const here = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+
+  // Preflight (including Private Network Access preflights).
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, corsHeaders());
+    res.end();
+    return;
+  }
+
+  if (here.pathname === '/health') {
+    send(res, 200, JSON.stringify({ ok: true }), { 'Content-Type': 'application/json' });
+    return;
+  }
+
+  if (here.pathname !== '/fetch') {
+    send(res, 404, 'Not found. Try /health or /fetch?url=https://...');
+    return;
+  }
+
+  const target = isAllowedTarget(here.searchParams.get('url') || '');
+  if (!target) {
+    send(res, 400, 'Only https:// URLs without embedded credentials are allowed.');
+    return;
+  }
+
+  let upstream;
+  try {
+    upstream = await fetchWithRedirects(target, MAX_REDIRECTS);
+  } catch (err) {
+    send(res, 502, 'Helper fetch failed: ' + (err && err.message ? err.message : String(err)));
+    return;
+  }
+
+  const declared = Number(upstream.headers['content-length'] || 0);
+  if (declared > MAX_BYTES) {
+    upstream.resume();
+    send(res, 413, `Upstream is ${declared} bytes; helper cap is ${MAX_BYTES}.`);
+    return;
+  }
+
+  res.writeHead(upstream.statusCode || 502, corsHeaders({
+    'Content-Type': upstream.headers['content-type'] || 'application/octet-stream',
+  }));
+
+  let seen = 0;
+  upstream.on('data', (chunk) => {
+    seen += chunk.length;
+    if (seen > MAX_BYTES) {
+      upstream.destroy();
+      res.destroy();
+    }
+  });
+  upstream.pipe(res);
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`SciREPL local fetch helper: http://127.0.0.1:${PORT}/`);
+  console.log(`Try:                        http://127.0.0.1:${PORT}/health`);
+  console.log('Stop with Ctrl+C when you are done installing packages.');
+});

--- a/tools/local-fetch-helper/local-fetch-helper.mjs
+++ b/tools/local-fetch-helper/local-fetch-helper.mjs
@@ -49,6 +49,9 @@ function corsHeaders(extra = {}) {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, OPTIONS',
     'Access-Control-Allow-Headers': '*',
+    // ETag is not a CORS-safelisted response header; without this the page's
+    // JS can see the body but not the validator it needs for If-None-Match.
+    'Access-Control-Expose-Headers': 'ETag, Last-Modified, Content-Length',
     // Private Network Access: a public-https page (a hosted PWA) calling
     // http://127.0.0.1 triggers a preflight that requires this header.
     'Access-Control-Allow-Private-Network': 'true',
@@ -73,9 +76,10 @@ function isAllowedTarget(raw) {
   return url;
 }
 
-function fetchWithRedirects(url, redirectsLeft) {
+function fetchWithRedirects(url, redirectsLeft, conditionalHeaders = {}) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, { headers: { 'User-Agent': 'scirepl-local-fetch-helper/1.0' } }, (upstream) => {
+    const headers = { 'User-Agent': 'scirepl-local-fetch-helper/1.0', ...conditionalHeaders };
+    const req = https.get(url, { headers }, (upstream) => {
       const code = upstream.statusCode || 0;
       if (code >= 300 && code < 400 && upstream.headers.location) {
         upstream.resume(); // drain so the socket can be reused
@@ -88,7 +92,7 @@ function fetchWithRedirects(url, redirectsLeft) {
           reject(new Error('Refused redirect to a non-https or credential-bearing URL'));
           return;
         }
-        resolve(fetchWithRedirects(next, redirectsLeft - 1));
+        resolve(fetchWithRedirects(next, redirectsLeft - 1, conditionalHeaders));
         return;
       }
       resolve(upstream);
@@ -124,9 +128,16 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  // Pass conditional-request headers through, so a catalog index re-fetch can
+  // be answered 304 Not Modified instead of re-downloading (the caching design
+  // in docs/proposal-catalog-browse.md relies on this).
+  const conditional = {};
+  if (req.headers['if-none-match']) conditional['If-None-Match'] = req.headers['if-none-match'];
+  if (req.headers['if-modified-since']) conditional['If-Modified-Since'] = req.headers['if-modified-since'];
+
   let upstream;
   try {
-    upstream = await fetchWithRedirects(target, MAX_REDIRECTS);
+    upstream = await fetchWithRedirects(target, MAX_REDIRECTS, conditional);
   } catch (err) {
     send(res, 502, 'Helper fetch failed: ' + (err && err.message ? err.message : String(err)));
     return;
@@ -139,9 +150,14 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  res.writeHead(upstream.statusCode || 502, corsHeaders({
-    'Content-Type': upstream.headers['content-type'] || 'application/octet-stream',
-  }));
+  // Forward Content-Length so the client can detect a mid-stream abort (the
+  // size-cap destroy below) as a truncated body rather than a complete file,
+  // and forward the validators the conditional headers above are answered by.
+  const passthrough = { 'Content-Type': upstream.headers['content-type'] || 'application/octet-stream' };
+  for (const name of ['content-length', 'etag', 'last-modified']) {
+    if (upstream.headers[name]) passthrough[name] = upstream.headers[name];
+  }
+  res.writeHead(upstream.statusCode || 502, corsHeaders(passthrough));
 
   let seen = 0;
   upstream.on('data', (chunk) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Design-only. No product code.

The Browse Packages, Bundles & Workbooks modal is a hardcoded curated list. This proposal keeps that list as the empty-search default, then adds:

- A search field that can surface **additional** items from user-added catalog indexes (search widens the pool; it does not replace the defaults).
- A **spoken-language** filter that defaults to the app locale (`i18n.current`). This is `Language-Interface`, not the editor kernel. Empty search does **not** hide built-in cards. Search **does** apply locale matching.
- An ordered **fallback list**, initialized to English, with **Allow fallbacks on**. First run, missing storage, and a missing `allowFallbacks` key all start allowed; only an explicit off-toggle stores `false`. Japanese UI → chain `['ja', 'en']`. Fallbacks off → primary locale only. All-languages mode ranks by the list but does not hide.
- A **programming-language** (kernel) filter as a second control, defaulting to **All** so first-open still matches today’s list.
- A Sources panel for HTTPS catalog index URLs (GitHub repo paste resolves to `scirepl-catalog.json` with a `locales` field).

The important constraint is CORS. SciREPL has no production backend, and `/proxy` is local-dev-only for GitHub release downloads.

- **PWA:** extra items only work if the index and artifacts are on a CORS-open host (`raw.githubusercontent.com`, jsDelivr). GitHub Releases will not install in the browser.
- **Android (Capacitor):** native HTTP can fetch arbitrary HTTPS, so community sources work more broadly.
- **Electron:** not like Android. `webSecurity` is on and there is no download IPC (renderer is untrusted because notebook JS shares `window`). Electron follows the PWA rules. This proposal does **not** add a privileged fetch channel.

Empty-search Browse stays offline and does not hit the network.

See `docs/proposal-catalog-browse.md` for UI sketches, the index schema, a platform matrix, implementation order, and open questions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48f5a6ce-d515-471f-97f2-aef66c7ba5e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48f5a6ce-d515-471f-97f2-aef66c7ba5e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

