### PR TITLE
Sync Pro privacy without advancing the Free PWA

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,6 +28,39 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # A Pro-only Pages update is overlaid onto the latest stable Free
+          # release below, so the release tags must be available locally.
+          fetch-depth: 0
+
+      - name: Keep Pro-only updates on the latest stable Free release
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pro_overlay="${RUNNER_TEMP}/scirepl-pro-pages"
+          mkdir -p "${pro_overlay}"
+          cp -a www/pro/. "${pro_overlay}/"
+
+          stable_tag=""
+          while IFS= read -r candidate; do
+            if [[ "${candidate}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              stable_tag="${candidate}"
+              break
+            fi
+          done < <(git tag --list 'v*' --sort=-version:refname)
+
+          if [[ -z "${stable_tag}" ]]; then
+            echo "No stable vMAJOR.MINOR.PATCH tag is available." >&2
+            exit 1
+          fi
+
+          git checkout --detach "${stable_tag}"
+          rm -rf -- www/pro
+          mkdir -p www/pro
+          cp -a "${pro_overlay}/." www/pro/
+          echo "Publishing Pro pages over stable Free release ${stable_tag} ($(git rev-parse HEAD))."
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/www/pro/privacy.html
+++ b/www/pro/privacy.html
@@ -53,7 +53,7 @@
 <body>
 <main>
     <h1>SciREPL Pro Privacy Policy</h1>
-    <p class="updated">Last updated: August 10, 2026</p>
+    <p class="updated">Last updated: August 14, 2026</p>
 
     <h2>Who this policy covers</h2>
     <p>This policy applies to <strong>SciREPL Pro</strong> on Android and in the Windows/Electron desktop container, developed by <a href="https://github.com/s243a" target="_blank" rel="noopener noreferrer">s243a</a>. The free SciREPL application has a <a href="../privacy.html">separate privacy policy</a>.</p>
@@ -103,7 +103,7 @@
         <li>The selected provider, model, model settings, and tool descriptions.</li>
         <li><strong>Automatically, up to the first 500 characters of every cell in the current notebook</strong>, together with each cell's number, name when present, and language.</li>
         <li>Earlier conversation content retained for the current AI session.</li>
-        <li>Results of tools that the model is permitted to use. These results can include full cell source, cell names and types, textual or structured cell output, namespace metadata, execution results, and files from permitted virtual-filesystem locations.</li>
+        <li>Results of tools that the model is permitted to use. These results can include full cell source, cell names and types, textual or structured cell output, namespace metadata, execution results, files from permitted virtual-filesystem locations, and—only when the separate Workbook import/export permission is enabled—the complete serialized active notebook.</li>
     </ul>
     <p>The 500-character cell preview is added before tool permissions are evaluated. Review mode and other tool permissions govern later tool calls; they do not remove the automatic previews from a new Direct AI message.</p>
     <p>Your saved API key is sent in an authentication header to the selected endpoint. That endpoint also receives ordinary network metadata such as your IP address, request time, and WebView or Electron/Chromium headers. OpenRouter may pass request content to the downstream model provider selected for the request. A custom or Ollama-compatible endpoint may be on your device, on your network, or operated by another party. SciREPL Pro requires non-loopback AI endpoints to use <code>https://</code>; unencrypted <code>http://</code> is accepted only for loopback hosts, such as localhost, 127.0.0.1, or ::1.</p>
@@ -116,6 +116,7 @@
         <li><strong>Open</strong> allows ordinary notebook tools and kernel execution without routine prompts, but it continues to respect the separate source-browsing and Agent writes scope settings, as well as explicit tool and kernel rules.</li>
         <li><strong>Per-kernel execution rules</strong> are available through <strong>Menu &gt; Languages &gt; AI Kernel Access</strong> and <strong>AI Settings &gt; Kernels</strong>. <strong>Default</strong> inherits the overall security level; <strong>Allow</strong> runs without a kernel prompt; <strong>Ask</strong> requests confirmation; and <strong>Deny</strong> blocks AI-initiated execution. TypR compiles to and executes R, so a TypR run requires permission for both the TypR and R kernels; the more restrictive result applies.</li>
         <li><strong>Review mode remains authoritative</strong> even when Full control is selected: it blocks kernel execution and ordinary edits or deletion. The separately enabled option to append review notes writes only to the dedicated AI Review worksheet.</li>
+        <li><strong>Workbook import/export is a separate permission</strong> that starts Off and does not inherit Full control, Open, or Agent writes. Ask requests approval for every call. Review mode always blocks workbook import; explicitly permitted export can still send the complete active notebook.</li>
         <li><strong>Remote-data consent is separate</strong> from the security level. The app requires it when opening or restoring a broker connection and again before handling a remote tool request. Selecting Full control does not grant remote consent. Direct AI consent and the automatic notebook previews described above are also separate from tool permissions.</li>
     </ul>
     <div class="warning">
@@ -124,7 +125,7 @@
 
     <h2 id="remote-mcp-bridge-and-remote-agents">Remote MCP bridge and remote agents</h2>
     <p>The Remote bridge is optional. You choose the broker URL and pairing token. SciREPL's developer does not provide or operate a default broker service.</p>
-    <p>When you connect, the app sends the pairing token and the available notebook-tool descriptions to the configured broker. External MCP clients or broker-spawned agents can then request permitted operations. Information sent through the broker can include tool arguments and results, cell lists and previews, full cell source, cell output, virtual files, namespace information, and code-execution results. Remote-agent chat also sends your chat messages to the broker and returns the agent's responses and activity.</p>
+    <p>When you connect, the app sends the pairing token and the available notebook-tool descriptions to the configured broker. External MCP clients or broker-spawned agents can then request permitted operations. Information sent through the broker can include tool arguments and results, cell lists and previews, full cell source, cell output, virtual files, namespace information, code-execution results, and—only when the separate Workbook import/export permission is enabled—the complete serialized active notebook. A permitted workbook import can replace the active tab or create a new one, but imported code is not executed automatically. Remote-agent chat also sends your chat messages to the broker and returns the agent's responses and activity.</p>
     <p>A remote agent such as Claude Code, Codex, Gemini, or another configured agent may forward prompts, notebook data, and tool results to its own model or service provider. The broker operator, external MCP client, remote-agent provider, and model provider may each have separate logging and retention practices.</p>
     <p>Review mode, security levels, write scope, and confirmation prompts can restrict tool calls handled by the app, but they do not control data already sent to the broker or the practices of software running on the broker host. Auto-connect, when enabled, reconnects to the selected broker when the app starts or returns to the foreground.</p>
     <p>SciREPL Pro requires non-loopback broker connections to use encrypted <code>wss://</code>; unencrypted <code>ws://</code> is accepted only for loopback hosts, such as localhost, 127.0.0.1, or ::1. Transport encryption protects the connection to the configured broker, but SciREPL cannot guarantee that a user-operated broker, downstream agent, model provider, or private network is securely configured or operated.</p>
@@ -138,8 +139,9 @@
     <ul>
         <li>Lua runtime files from jsDelivr or unpkg.</li>
         <li>Fallback runtime files and optional Python or R packages from their configured repositories or mirrors.</li>
-        <li>Optional packages and workbooks from the SciREPL site or GitHub.</li>
-        <li>The DOCX export library from jsDelivr when DOCX export is requested.</li>
+        <li>After you accept the current network disclosure, opening Languages may query <code>data.jsdelivr.com</code> for R and Prolog package-version metadata. If consent has not yet been given, choosing <strong>Check latest</strong> opens this privacy dialog; no metadata request is sent unless you accept. The lookup does not download or activate a runtime.</li>
+        <li>When you open Browse after accepting the current disclosure, verified SciREPL Catalog release metadata from the configured static catalogue host (by default <code>s243a.github.io</code>) and immutable catalogue or workbook bytes from <code>raw.githubusercontent.com</code>. These requests do not intentionally include notebook content, search text, spoken-language choices, fallback preferences, or kernel filters. Selecting a development branch additionally asks <code>api.github.com</code> to resolve that branch to an exact commit.</li>
+        <li>The DOCX export library (docx@9.6.0) from jsDelivr when DOCX export is requested.</li>
         <li>Ko-fi when you choose the external support link.</li>
         <li>Files or URLs explicitly requested by notebook code or file-fetching features.</li>
     </ul>


### PR DESCRIPTION
## Summary

- synchronize the canonical public SciREPL Pro privacy policy with the current packaged Pro policy
- disclose the separate workbook import/export permission and whole-notebook transfer
- disclose runtime-version metadata checks and verified SciREPL Catalog requests, including configurable static hosts, immutable GitHub content, and development-branch API resolution
- keep the Pages copy's relative link to the separate Free policy
- make Pro-only Pages updates overlay onto the latest immutable stable Free release instead of accidentally deploying unreleased Free `main`

## Why

SciREPL Pro links to `https://s243a.github.io/SciREPL/pro/privacy.html` as its canonical public and Play Store-facing policy. That hosted copy predates the workbook-transfer and verified catalogue features, so it must be current before those Pro changes are distributed.

The existing Pages workflow uploaded the entire current `www` tree for a `www/pro/**` change. Today that would advance the public Free PWA from released `v1.2.0` / shell `v155` to unreleased `main` / shell `v160`. For a Pro-only main-branch update, the workflow now checks out the newest strict `vMAJOR.MINOR.PATCH` tag and overlays only current `www/pro/**`. Tag-triggered releases remain unchanged.

This does not port the remote catalogue loader into Free.

## Deployment

After merge, the existing Pages workflow will test and publish the stable Free app plus the updated Pro pages. No service-worker bump is needed because the Free worker intentionally excludes `/pro/`.

## Checks

- `npm run i18n:check` (includes `privacy:check`)
- `git diff --check`
- normalized byte comparison against SciREPL Pro's packaged `www/privacy.html`
- local artifact simulation: stable `v1.2.0` remains service-worker `v155`, while the overlaid Pro policy matches this branch
