### PR TITLE
Attach the Windows portable build to tagged releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,8 @@
-name: Build Release (APK + PWA)
+# A `v*` tag runs the branch gates, then builds the unsigned Android APK, the
+# PWA zip and the unsigned portable Windows application, and attaches all three
+# to a pre-release. Release assets do not expire; the workflow artifacts uploaded
+# by windows-portable-preview.yml are deleted after fourteen days.
+name: Build Release (APK + PWA + Windows)
 
 on:
   push:
@@ -53,8 +57,85 @@ jobs:
       - run: node test_notebook_vfs.mjs
       - run: npm run test:catalog:import
 
-  build:
+  # The unsigned portable Windows application. windows-portable-preview.yml
+  # builds the same thing on demand, but uploads it as a workflow artifact that
+  # GitHub deletes after fourteen days. A tagged build is meant to outlive that,
+  # so here it is handed to the release job and attached to the release itself,
+  # alongside the APK and the PWA zip.
+  windows-portable:
     needs: test
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install root dependencies
+        run: npm install
+
+      - name: Check committed component notices and release metadata
+        run: npm run licenses:check && npm run release:check
+
+      # The Free profile. build-portable.mjs refuses to package the `pro`
+      # profile or a tree containing the offline R runtime, so this is enforced
+      # rather than assumed.
+      - name: Configure the Free build profile
+        run: npm run configure
+
+      - name: Fetch the Free bundled runtimes
+        run: npm run fetch:bundles
+
+      - name: Verify completed bundle inventories and wheel notices
+        run: npm run verify:bundles
+
+      - name: Install Electron (isolated, pinned)
+        run: npm run windows:install
+
+      - name: Build the portable application
+        run: npm run package:windows
+
+      - name: Verify the packaged application
+        run: node desktop/electron/test/run-all.mjs packaged
+
+      - name: Zip the portable application
+        shell: pwsh
+        run: |
+          $tree = 'desktop/electron/out/SciREPL-win32-x64'
+          if (-not (Test-Path $tree)) { throw "packaging produced nothing at $tree" }
+          $zip = "SciREPL-${{ github.ref_name }}-windows-x64-portable.zip"
+          if (Get-Command 7z -ErrorAction SilentlyContinue) {
+            7z a -tzip -mx=5 "$zip" "$tree/*"
+            if ($LASTEXITCODE -ne 0) { throw "7z failed with $LASTEXITCODE" }
+          } else {
+            Compress-Archive -Path "$tree/*" -DestinationPath "$zip" -CompressionLevel Optimal
+          }
+          "{0} is {1:N0} bytes" -f $zip, (Get-Item $zip).Length
+
+      - name: Hand the zip to the release job
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-portable-zip
+          path: SciREPL-${{ github.ref_name }}-windows-x64-portable.zip
+          if-no-files-found: error
+          retention-days: 7
+          # Already a compressed archive; recompressing buys nothing.
+          compression-level: 0
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-portable-test-results
+          path: desktop/electron/test/results/
+          if-no-files-found: warn
+
+  build:
+    needs:
+      - test
+      - windows-portable
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -140,12 +221,18 @@ jobs:
             -x "*.DS_Store"
           cd ..
 
+      - name: Collect the Windows portable zip
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-portable-zip
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             android/app/build/outputs/apk/release/SciREPL-${{ github.ref_name }}-unsigned.apk
             SciREPL-${{ github.ref_name }}-pwa.zip
+            SciREPL-${{ github.ref_name }}-windows-x64-portable.zip
           prerelease: true
           body: |
             > **Pre-release** — unsigned APK for testing. After signing, upload `SciREPL-${{ github.ref_name }}.apk` and mark as latest release.
@@ -156,6 +243,21 @@ jobs:
             - **Android APK (unsigned):** `SciREPL-${{ github.ref_name }}-unsigned.apk` — requires signing before install (see below)
             - **PWA (zip):** `SciREPL-${{ github.ref_name }}-pwa.zip` — unzip and serve over HTTPS or localhost (service workers do not run from `file://`)
             - **PWA (live):** [https://s243a.github.io/SciREPL/](https://s243a.github.io/SciREPL/) — install from browser, no app store needed
+            - **Windows portable (unsigned, x64):** `SciREPL-${{ github.ref_name }}-windows-x64-portable.zip` — extract and run, no installer
+
+            ## Running the Windows portable build
+
+            Extract the zip to a local folder (not a network path) and run **SciREPL.exe**.
+            There is no installer and nothing is registered with the operating system.
+
+            The build is **unsigned**, so Windows SmartScreen shows "Windows protected
+            your PC" on first run — choose **More info → Run anyway**. That is expected
+            for an unsigned build and is not a sign of a problem.
+
+            Bash/Brush, ClojureScript/Scittle, SWI-Prolog and Python/Pyodide are bundled
+            and work offline. Lua and R download from their CDNs on first use, then run
+            offline from SciREPL's own runtime cache. Application data lives under
+            `%APPDATA%\SciREPL-Free-Electron`. See `docs/WINDOWS_PREVIEW.md`.
 
             ## Updating the PWA
 

--- a/docs/WINDOWS_PREVIEW.md
+++ b/docs/WINDOWS_PREVIEW.md
@@ -29,6 +29,17 @@ runs the bundled kernels, and keeps notebook/SharedVFS state across a restart.
 4. When it finishes, download the artifact named
    `SciREPL-windows-x64-preview-<commit>` from the run summary.
 
+Workflow artifacts are deleted fourteen days after the run.
+
+### Or take it from a tagged release
+
+Pushing a `v*` tag runs **Build Release (APK + PWA + Windows)**, which builds the
+same portable application and attaches
+`SciREPL-<tag>-windows-x64-portable.zip` to that tag's pre-release, next to the
+APK and the PWA zip. Release assets do not expire, so this is the copy to use for
+anything that needs to outlive a fortnight — sharing with a tester, or pointing
+someone at a specific version.
+
 ### Run it
 
 1. Extract the ZIP to a **local** folder — `C:\Users\<you>\SciREPL-preview` is


### PR DESCRIPTION
Port of [SciREPL-Pro#40](https://github.com/s243a/SciREPL-Pro/pull/40) to the free repo.

## What this fixes

A `v*` tag ran **Build Release (APK + PWA)**, which attached two permanent assets: the unsigned APK and the PWA zip. The desktop application was not among them. `windows-portable-preview.yml` is the only thing that packages it, and it is `workflow_dispatch`-only with `retention-days: 14` — so the Windows build either did not exist for a given tag or expired a fortnight later.

## Change

- New `windows-portable` job in `build-release.yml`, gated on the existing `test` job. It mirrors the step sequence already proven in `windows-portable-preview.yml` (configure, fetch bundles, `windows:install`, `package:windows`, packaged suite), adds `verify:bundles` and `release:check` for consistency with the other release jobs, and zips `desktop/electron/out/SciREPL-win32-x64/`.
- `build` now `needs` it, downloads the zip, and attaches `SciREPL-<tag>-windows-x64-portable.zip` alongside the APK and PWA zip. One release, one body, no race between two `action-gh-release` calls.
- Workflow renamed to `Build Release (APK + PWA + Windows)`; the release body documents the Windows download, the SmartScreen warning, which kernels are bundled offline, and the `%APPDATA%\SciREPL-Free-Electron` data location.
- `docs/WINDOWS_PREVIEW.md` gains a "take it from a tagged release" section and now states the fourteen-day artifact expiry explicitly.

## Verification

`node desktop/electron/test/run-all.mjs --unit` on this branch: **130 assertions pass, 0 fail** (policy-unit 100, native-i18n 30).

Note that `build-release.yml` only triggers on tags, so this PR's CI does not exercise the new job. The steps are copied from the preview workflow, so dispatching **Windows portable preview** against `main` is the cheapest pre-tag confidence check.

## Deliberately not included

The preview workflow's opt-in Linux cross-build. It is built-not-tested there by design, and shipping an unexecuted binary as a permanent release asset is a separate decision — easy to add later as one more `--platform linux` invocation plus a second zip.

## Cost

The tag pipeline now blocks on a windows-latest job (90 min timeout, ~25-40 min expected) before publishing, so a release takes longer. That is deliberate: the release is atomic rather than trickling assets in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc